### PR TITLE
Add support for BARE (serde_bare)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rkyv = { version = "0.7", features = ["validation"], optional = true }
 rmp-serde = { version = "0.15", optional = true }
 ron = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_bare = { version = "0.5.0", optional = true }
 serde_cbor = { version = "0.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 simd-json = { version = "0.4", optional = true }
@@ -59,6 +60,7 @@ default = [
     "rmp-serde",
     "ron",
     "serde",
+    "serde_bare",
     "serde_cbor",
     "serde_json",
     "simd-json",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,6 +6,8 @@ use rust_serialization_benchmark::generate_vec;
 use rust_serialization_benchmark::bench_abomonation;
 #[cfg(feature = "alkahest")]
 use rust_serialization_benchmark::bench_alkahest;
+#[cfg(feature = "serde_bare")]
+use rust_serialization_benchmark::bench_bare;
 #[cfg(feature = "bincode")]
 use rust_serialization_benchmark::bench_bincode;
 #[cfg(feature = "borsh")]
@@ -61,6 +63,9 @@ fn bench_log(c: &mut Criterion) {
             black_box(log.size);
         }
     });
+
+    #[cfg(feature = "serde_bare")]
+    bench_bare::bench(BENCH, c, &data);
 
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);
@@ -207,6 +212,9 @@ fn bench_mesh(c: &mut Criterion) {
         }
     });
 
+    #[cfg(feature = "serde_bare")]
+    bench_bare::bench(BENCH, c, &data);
+
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);
 
@@ -334,6 +342,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
             black_box(player.game_type);
         }
     });
+
+    #[cfg(feature = "serde_bare")]
+    bench_bare::bench(BENCH, c, &data);
 
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);

--- a/src/bench_bare.rs
+++ b/src/bench_bare.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, Criterion};
+use serde::{Deserialize, Serialize};
+
+pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
+where
+    T: Serialize + for<'de> Deserialize<'de>,
+{
+    const BUFFER_LEN: usize = 50_000_000;
+
+    let mut group = c.benchmark_group(format!("{}/bare", name));
+
+    let mut serialize_buffer = vec![0; BUFFER_LEN];
+    group.bench_function("serialize", |b| {
+        b.iter(|| {
+            black_box(
+                serde_bare::to_writer(black_box(serialize_buffer.as_mut_slice()), black_box(&data))
+                    .unwrap(),
+            );
+        })
+    });
+
+    let mut deserialize_buffer = Vec::new();
+    serde_bare::to_writer(&mut deserialize_buffer, &data).unwrap();
+
+    group.bench_function("deserialize", |b| {
+        b.iter(|| {
+            black_box(serde_bare::from_slice::<T>(black_box(&deserialize_buffer)).unwrap());
+        })
+    });
+
+    crate::bench_size(name, "bare", deserialize_buffer.as_slice());
+
+    group.finish();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 pub mod bench_abomonation;
 #[cfg(feature = "alkahest")]
 pub mod bench_alkahest;
+#[cfg(feature = "serde_bare")]
+pub mod bench_bare;
 #[cfg(feature = "bincode")]
 pub mod bench_bincode;
 #[cfg(feature = "borsh")]


### PR DESCRIPTION
Thanks for this benchmark!

I like BARE's dense encoding quite a bit, so thought it'd be interesting to see how it stacks up against the competition. I've only run the benchmark for a few of the libraries that I've been considering (partially because some of the other benchmarks don't compile, or need external tools which weren't easy to figure out how to install).

EDIT: Here are the results for the formats I was particularly interested in. BARE seems to have an advantage when it comes to size, which is interesting to know :).

## `log`

This data set is composed of HTTP request logs that are small and contain many strings.

### Raw Data

For operations, time per iteration; for size, bytes. Lower is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 614.03 us | 2.9164 ms | 765778 | 312739 | 264630 |
| bincode | 474.82 us | 2.2372 ms | 1045784 | 374305 | 311761 |
| cbor | 1.6595 ms | 5.9777 ms | 1407835 | 407372 | 324081 |
| rkyv | 183.76 us | <span title="unvalidated">*1.3184 ms\**</span> <span title="validated upfront with error">*1.9008 ms\**</span> | 1011488 | 392809 | 331932 |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="unvalidated">*1.0035 ns\**</span> <span title="validated upfront with error">*591.06 us\**</span> | <span title="unvalidated">*9.5201 us\**</span> <span title="validated upfront with error">*600.61 us\**</span> | 44.896 us |

### Comparison

Relative to best. Higher is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 29.93% | 45.21% | 100.00% | 100.00% | 100.00% |
| bincode | 38.70% | 58.93% | 73.23% | 83.55% | 84.88% |
| cbor | 11.07% | 22.06% | 54.39% | 76.77% | 81.66% |
| rkyv | 100.00% | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*69.36%\**</span> | 75.71% | 79.62% | 79.72% |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*0.00%\**</span> | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*1.59%\**</span> | 100.00% |

## `mesh`

This data set is a single mesh. The mesh contains an array of triangles, each of which has three vertices and a normal vector.

### Raw Data

For operations, time per iteration; for size, bytes. Lower is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 4.1581 ms | 7.6070 ms | 6000003 | 5380817 | 5345900 |
| bincode | 4.9309 ms | 3.3888 ms | 6000008 | 5380823 | 5345890 |
| cbor | 36.111 ms | 59.945 ms | 13122324 | 7527423 | 6759658 |
| rkyv | 474.21 us | <span title="unvalidated">*329.20 us\**</span> <span title="validated upfront with error">*318.65 us\**</span> | 6000008 | 5380822 | 5345892 |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="unvalidated">*1.0050 ns\**</span> <span title="validated upfront with error">*12.374 ns\**</span> | <span title="unvalidated">*35.804 us\**</span> <span title="validated upfront with error">*34.760 us\**</span> | 192.25 us |

### Comparison

Relative to best. Higher is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 11.40% | 4.19% | 100.00% | 100.00% | 100.00% |
| bincode | 9.62% | 9.40% | 100.00% | 100.00% | 100.00% |
| cbor | 1.31% | 0.53% | 45.72% | 71.48% | 79.09% |
| rkyv | 100.00% | <span title="unvalidated">*96.80%\**</span> <span title="validated upfront with error">*100.00%\**</span> | 100.00% | 100.00% | 100.00% |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*8.12%\**</span> | <span title="unvalidated">*97.08%\**</span> <span title="validated upfront with error">*100.00%\**</span> | 100.00% |

## `minecraft_savedata`

This data set is composed of Minecraft player saves that contain highly structured data.

### Raw Data

For operations, time per iteration; for size, bytes. Lower is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 659.83 us | 2.7228 ms | 356311 | 213270 | 198488 |
| bincode | 473.08 us | 1.9039 ms | 569975 | 240897 | 232423 |
| cbor | 1.6809 ms | 5.5620 ms | 1109821 | 347812 | 274526 |
| rkyv | 303.12 us | <span title="unvalidated">*1.1217 ms\**</span> <span title="validated upfront with error">*1.6373 ms\**</span> | 596952 | 254571 | 219976 |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="validated upfront with error">*495.72 us\**</span> | <span title="unvalidated">*255.19 ns\**</span> <span title="validated upfront with error">*494.63 us\**</span> | 2.7913 us |

### Comparison

Relative to best. Higher is better.

#### Serialize / deserialize speed and size

| Format / Lib | Serialize | Deserialize | Size | Zlib | Zstd |
|---|--:|--:|--:|--:|--:|
| bare | 45.94% | 41.20% | 100.00% | 100.00% | 100.00% |
| bincode | 64.07% | 58.92% | 62.51% | 88.53% | 85.40% |
| cbor | 18.03% | 20.17% | 32.11% | 61.32% | 72.30% |
| rkyv | 100.00% | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*68.51%\**</span> | 59.69% | 83.78% | 90.23% |

#### Zero-copy deserialization speed

| Format / Lib | Access | Read | Update |
|---|--:|--:|--:|
| rkyv | <span title="validated upfront with error">*100.00%\**</span> | <span title="unvalidated">*100.00%\**</span> <span title="validated upfront with error">*0.05%\**</span> | 100.00% |

