### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/bench_abomonation.rs
+++ b/src/bench_abomonation.rs
@@ -39,8 +39,8 @@ where
     });
 
     group.bench_function("deserialize (unvalidated)", |b| {
-        b.iter(|| unsafe {
-            let (data, _) = decode::<T>(black_box(&mut deserialize_buffer)).unwrap();
+        b.iter(|| {
+            let (data, _) = unsafe { decode::<T>(black_box(&mut deserialize_buffer)).unwrap() };
             black_box((*data).clone());
         })
     });


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
References
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html