### PR TITLE
Add bitcode 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ abomonation_derive = { version = "0.5.0", optional = true }
 alkahest = { version = "0.1.5", optional = true, features = ["derive", "nightly"] }
 bebop = { version = "2.4.9", optional = true }
 bincode = { version = "1.3.3", optional = true }
+bitcode = { version = "0.2.1", optional = true }
 borsh = { version = "0.10.2", optional = true }
 bson = { version = "2.0", git = "https://github.com/djkoloski/bson-rust", branch = "master", optional = true }
 bytecheck = { version = "0.6.10", optional = true }
@@ -47,6 +48,7 @@ default = [
   "alkahest",
   # "bebop",
   "bincode",
+  "bitcode",
   "borsh",
   "bson",
   "bytecheck",
@@ -87,5 +89,6 @@ name = "bench"
 
 [profile.bench]
 lto = true
+debug-assertions = true
 # Uncomment this to profile
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,5 @@ name = "bench"
 
 [profile.bench]
 lto = true
-debug-assertions = true
 # Uncomment this to profile
 # debug = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,6 +8,8 @@ use rust_serialization_benchmark::bench_alkahest;
 use rust_serialization_benchmark::bench_bare;
 #[cfg(feature = "bincode")]
 use rust_serialization_benchmark::bench_bincode;
+#[cfg(feature = "bitcode")]
+use rust_serialization_benchmark::bench_bitcode;
 #[cfg(feature = "borsh")]
 use rust_serialization_benchmark::bench_borsh;
 #[cfg(feature = "bson")]
@@ -72,6 +74,9 @@ fn bench_log(c: &mut Criterion) {
 
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);
+
+    #[cfg(feature = "bitcode")]
+    bench_bitcode::bench(BENCH, c, &data);
 
     #[cfg(feature = "borsh")]
     bench_borsh::bench(BENCH, c, &data);
@@ -227,6 +232,9 @@ fn bench_mesh(c: &mut Criterion) {
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);
 
+    #[cfg(feature = "bitcode")]
+    bench_bitcode::bench(BENCH, c, &data);
+
     #[cfg(feature = "borsh")]
     bench_borsh::bench(BENCH, c, &data);
 
@@ -363,6 +371,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
 
     #[cfg(feature = "bincode")]
     bench_bincode::bench(BENCH, c, &data);
+
+    #[cfg(feature = "bitcode")]
+    bench_bitcode::bench(BENCH, c, &data);
 
     #[cfg(feature = "borsh")]
     bench_borsh::bench(BENCH, c, &data);

--- a/build.rs
+++ b/build.rs
@@ -58,7 +58,6 @@ fn prost_compile_dataset(name: &'static str) -> std::io::Result<()> {
 }
 
 fn main() {
-    return;
     const DATASETS: [&str; 3] = ["log", "mesh", "minecraft_savedata"];
     for &name in DATASETS.iter() {
         // bebop_compile_dataset(name);

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,7 @@ fn prost_compile_dataset(name: &'static str) -> std::io::Result<()> {
 }
 
 fn main() {
+    return;
     const DATASETS: [&str; 3] = ["log", "mesh", "minecraft_savedata"];
     for &name in DATASETS.iter() {
         // bebop_compile_dataset(name);

--- a/src/bench_bitcode.rs
+++ b/src/bench_bitcode.rs
@@ -1,0 +1,31 @@
+use criterion::{black_box, Criterion};
+use serde::{Deserialize, Serialize};
+
+pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
+where
+    T: Serialize + for<'de> Deserialize<'de>,
+{
+    let mut group = c.benchmark_group(format!("{}/bitcode", name));
+    let mut buffer = bitcode::Buffer::with_capacity(1000000);
+
+    group.bench_function("serialize", |b| {
+        b.iter(|| {
+            buffer.serialize(black_box(&data))
+                .unwrap();
+            black_box(());
+        })
+    });
+
+    let encoded = bitcode::serialize(&data).unwrap();
+    let mut buffer = bitcode::Buffer::with_capacity(1000000);
+
+    group.bench_function("deserialize", |b| {
+        b.iter(|| {
+            black_box(buffer.deserialize::<T>(black_box(&encoded)).unwrap());
+        })
+    });
+
+    crate::bench_size(name, "bitcode", encoded.as_slice());
+
+    group.finish();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod bench_alkahest;
 pub mod bench_bare;
 #[cfg(feature = "bincode")]
 pub mod bench_bincode;
+#[cfg(feature = "bitcode")]
+pub mod bench_bitcode;
 #[cfg(feature = "borsh")]
 pub mod bench_borsh;
 #[cfg(feature = "bson")]


### PR DESCRIPTION
Bitcode is a new bit-wise format for serde :tada:

```console
log/bitcode/size 758664
mesh/bitcode/size 6000005
minecraft_savedata/bitcode/size 333471
```
