### PR TITLE
Upgrade to bitcode@0.3.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ abomonation_derive = { version = "0.5.0", optional = true }
 alkahest = { version = "0.1.5", optional = true, features = ["derive", "nightly"] }
 bebop = { version = "2.4.9", optional = true }
 bincode = { version = "1.3.3", optional = true }
-bitcode = { version = "0.2.1", optional = true }
+bitcode = { version = "0.3.0", optional = true }
 borsh = { version = "0.10.2", optional = true }
 bson = { version = "2.0", git = "https://github.com/djkoloski/bson-rust", branch = "master", optional = true }
 bytecheck = { version = "0.6.10", optional = true }

--- a/src/bench_bitcode.rs
+++ b/src/bench_bitcode.rs
@@ -1,27 +1,26 @@
+use bitcode::{Decode, Encode};
 use criterion::{black_box, Criterion};
-use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Encode + Decode,
 {
     let mut group = c.benchmark_group(format!("{}/bitcode", name));
-    let mut buffer = bitcode::Buffer::with_capacity(1000000);
+    let mut buffer = bitcode::Buffer::with_capacity(10000000);
 
     group.bench_function("serialize", |b| {
         b.iter(|| {
-            buffer.serialize(black_box(&data))
+            buffer.encode(black_box(&data))
                 .unwrap();
             black_box(());
         })
     });
 
-    let encoded = bitcode::serialize(&data).unwrap();
-    let mut buffer = bitcode::Buffer::with_capacity(1000000);
+    let encoded = bitcode::encode(&data).unwrap();
 
     group.bench_function("deserialize", |b| {
         b.iter(|| {
-            black_box(buffer.deserialize::<T>(black_box(&encoded)).unwrap());
+            black_box(buffer.decode::<T>(black_box(&encoded)).unwrap());
         })
     });
 

--- a/src/datasets/log/mod.rs
+++ b/src/datasets/log/mod.rs
@@ -31,6 +31,7 @@ use crate::Generate;
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -118,6 +119,7 @@ impl alkahest::Pack<Address> for Address {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -139,7 +141,9 @@ pub struct Log {
     pub userid: String,
     pub date: String,
     pub request: String,
+    #[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "100..599"))]
     pub code: u16,
+    #[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "0..100000000"))]
     pub size: u64,
 }
 
@@ -314,6 +318,7 @@ impl alkahest::Pack<LogSchema> for &'_ Log {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/src/datasets/mesh/mod.rs
+++ b/src/datasets/mesh/mod.rs
@@ -29,6 +29,8 @@ use crate::Generate;
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
+#[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "0.0..1.0"))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -111,6 +113,7 @@ impl alkahest::Pack<Vector3> for Vector3 {
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -204,6 +207,7 @@ impl alkahest::Pack<Triangle> for &'_ Triangle {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -31,6 +31,7 @@ use crate::{generate_vec, Generate};
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -121,6 +122,7 @@ impl alkahest::Pack<GameType> for GameType {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -231,6 +233,8 @@ impl alkahest::Pack<ItemSchema> for &'_ Item {
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
+#[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "0.0..1.0"))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -341,6 +345,8 @@ impl alkahest::Pack<Abilities> for Abilities {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
+#[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "0.0..1.0"))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -591,6 +597,7 @@ impl alkahest::Pack<EntitySchema> for &'_ Entity {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -785,6 +792,8 @@ impl alkahest::Pack<RecipeBookSchema> for &'_ RecipeBook {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
+#[cfg_attr(feature = "bitcode", bitcode_hint(expected_range = "0.0..1.0"))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -1220,6 +1229,7 @@ impl alkahest::Pack<PlayerSchema> for &'_ Player {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "abomonation", derive(abomonation_derive::Abomonation))]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)


### PR DESCRIPTION
`bitcode` 0.3.0 adds a new set of derive macros that allow finer-grained control, leading to smaller serialized sizes across all 3 benchmarks.