### PR TITLE
Add dlhn benchmark to the bench_minecraft_savedata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ alkahest = { version = "0.1.5", optional = true, features = [
 ] }
 bebop = { version = "2.4.9", optional = true }
 bincode = { version = "1.3.3", optional = true }
-bitcode = { version = "0.3.7", optional = true }
+bitcode = { version = "0.4", optional = true }
 borsh = { version = "0.10.3", optional = true }
 # TODO: Unfork after bson adds support for pre-warmed serialization buffers
 # https://github.com/mongodb/bson-rust/pull/328

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -391,6 +391,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     #[cfg(feature = "ciborium")]
     bench_ciborium::bench(BENCH, c, &data);
 
+    #[cfg(feature = "dlhn")]
+    bench_dlhn::bench(BENCH, c, &data);
+
     #[cfg(feature = "flatbuffers")]
     bench_flatbuffers::bench(
         BENCH,

--- a/src/bench_ciborium.rs
+++ b/src/bench_ciborium.rs
@@ -23,7 +23,7 @@ where
 
     group.bench_function("deserialize", |b| {
         b.iter(|| {
-            black_box(ciborium::de::from_reader::<'_, T, _>(black_box(deserialize_buffer.as_slice())).unwrap());
+            black_box(ciborium::de::from_reader::<T, _>(black_box(deserialize_buffer.as_slice())).unwrap());
         })
     });
 


### PR DESCRIPTION
This PR adds the `dlhn` benchmark to the `bench_minecraft_savedata` and includes a fix for the build failure issue.
Please review and provide any feedback. Thanks!
