### PR TITLE
Step savefile to version 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ serde_json = { version = "1.0.96", optional = true }
 simd-json = { version = "0.9.2", optional = true }
 simd-json-derive = { version = "0.9.2", optional = true }
 speedy = { version = "0.8.6", optional = true }
-savefile = { version = "0.14", optional = true }
-savefile-derive = { version = "0.14", optional = true }
+savefile = { version = "0.15", optional = true }
+savefile-derive = { version = "0.15", optional = true }
 zstd = "0.12.3"
 
 [features]


### PR DESCRIPTION
I found a way to get the performance improvements in savefile that previously required 'unsafe', without requiring 'unsafe'.

It should be perfectly safe, and makes savefile much  more competitive, particular in the 'mesh' bench.

I've made a PR to step the version used by the benchmark up to 0.15.
