### PR TITLE
Update savefile to version 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ serde_json = { version = "1.0.96", optional = true }
 simd-json = { version = "0.9.2", optional = true }
 simd-json-derive = { version = "0.9.2", optional = true }
 speedy = { version = "0.8.6", optional = true }
-savefile = { version = "0.15", optional = true }
-savefile-derive = { version = "0.15", optional = true }
+savefile = { version = "0.16", optional = true }
+savefile-derive = { version = "0.16", optional = true }
 zstd = "0.12.3"
 
 [features]


### PR DESCRIPTION
I've been running the benchmark a lot, and investigated why savefile didn't perform as well as some of the other libraries.

This proved very helpful, and I've realized that carrying a '&mut dyn Write' instead of making the serializer generic was very expensive. So, I've redesigned this aspect of Savefile, and done some more optimizations, and released version 0.16.

It is much faster!

It would be nice to have this new version in the benchmark!