### PR TITLE
add pot to benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ nanoserde = {version = "0.1.33", optional = true }
 parity-scale-codec = { version = "3.5.0", features = ["full"], optional = true }
 parity-scale-codec-derive = { version = "3.1.4", optional = true }
 postcard = { version = "1.0.4", features = ["alloc"], optional = true }
+pot = { version = "3.0.0", optional = true }
 prost = { version = "0.11.9", optional = true }
 rand = "0.8.5"
 rkyv = { version = "0.7.41", features = ["validation"], optional = true }
@@ -107,6 +108,7 @@ default = [
   "nanoserde",
   "scale",
   "postcard",
+  "pot",
   "prost",
   "prost-build",
   "rkyv",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -30,6 +30,8 @@ use rust_serialization_benchmark::bench_nanoserde;
 use rust_serialization_benchmark::bench_parity_scale_codec;
 #[cfg(feature = "postcard")]
 use rust_serialization_benchmark::bench_postcard;
+#[cfg(feature = "pot")]
+use rust_serialization_benchmark::bench_pot;
 #[cfg(feature = "prost")]
 use rust_serialization_benchmark::bench_prost;
 #[cfg(feature = "rkyv")]
@@ -157,6 +159,9 @@ fn bench_log(c: &mut Criterion) {
 
     #[cfg(feature = "postcard")]
     bench_postcard::bench(BENCH, c, &data);
+
+    #[cfg(feature = "pot")]
+    bench_pot::bench(BENCH, c, &data);
 
     #[cfg(feature = "prost")]
     bench_prost::bench(BENCH, c, &data);
@@ -314,6 +319,9 @@ fn bench_mesh(c: &mut Criterion) {
     #[cfg(feature = "postcard")]
     bench_postcard::bench(BENCH, c, &data);
 
+    #[cfg(feature = "pot")]
+    bench_pot::bench(BENCH, c, &data);
+
     #[cfg(feature = "prost")]
     bench_prost::bench(BENCH, c, &data);
 
@@ -460,6 +468,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
 
     #[cfg(feature = "postcard")]
     bench_postcard::bench(BENCH, c, &data);
+
+    #[cfg(feature = "pot")]
+    bench_pot::bench(BENCH, c, &data);
 
     #[cfg(feature = "prost")]
     bench_prost::bench(BENCH, c, &data);
@@ -611,6 +622,9 @@ fn bench_mk48(c: &mut Criterion) {
 
     #[cfg(feature = "postcard")]
     bench_postcard::bench(BENCH, c, &data);
+
+    #[cfg(feature = "pot")]
+    bench_pot::bench(BENCH, c, &data);
 
     #[cfg(feature = "prost")]
     bench_prost::bench(BENCH, c, &data);

--- a/src/bench_pot.rs
+++ b/src/bench_pot.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, Criterion};
+use serde::{Deserialize, Serialize};
+
+pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
+where
+    T: Serialize + for<'de> Deserialize<'de>,
+{
+    const BUFFER_LEN: usize = 70_000_000;
+
+    let mut group = c.benchmark_group(format!("{}/pot", name));
+
+    let mut serialize_buffer = vec![0; BUFFER_LEN];
+    group.bench_function("serialize", |b| {
+        b.iter(|| {
+            black_box(
+                pot::to_writer(black_box(&data), black_box(serialize_buffer.as_mut_slice()))
+                    .unwrap(),
+            );
+        })
+    });
+
+    let deserialize_buffer = pot::to_vec(&data).unwrap();
+
+    group.bench_function("deserialize", |b| {
+        b.iter(|| {
+            black_box(pot::from_slice::<T>(black_box(&deserialize_buffer)).unwrap());
+        })
+    });
+
+    crate::bench_size(name, "pot", deserialize_buffer.as_slice());
+
+    group.finish();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod bench_nanoserde;
 pub mod bench_parity_scale_codec;
 #[cfg(feature = "postcard")]
 pub mod bench_postcard;
+#[cfg(feature = "pot")]
+pub mod bench_pot;
 #[cfg(feature = "prost")]
 pub mod bench_prost;
 #[cfg(feature = "rkyv")]


### PR DESCRIPTION
This adds [pot](https://github.com/khonsulabs/pot), a self-describing binary format for serde to the benchmarks

I mostly copied postcards benches and adjusted accordingly, not sure if i missed anything
Also added to the default features

from my testing it's a little behind serde_cbor time-wise and bincode size-wise, which aligns with their own benchmarks

