### PR TITLE
bump nanoserde version to v0.1.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ flatbuffers = { version = "23.1.21", optional = true }
 libflate = "1.3.0"
 msgpacker = { version = "0.4", optional = true }
 nachricht-serde = { version = "0.4.0", optional = true }
-nanoserde = {version = "0.1.33", optional = true }
+nanoserde = {version = "0.1.35", optional = true }
 parity-scale-codec = { version = "3.5.0", features = ["full"], optional = true }
 parity-scale-codec-derive = { version = "3.1.4", optional = true }
 postcard = { version = "1.0.4", features = ["alloc"], optional = true }


### PR DESCRIPTION
did some perf work on nanoserde, would like to bump the version to include it