### PR TITLE
check for deserialized equality to ensure round-tripping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ ron = { version = "0.8.1", optional = true }
 serde = { version = "1.0.190", features = ["derive"], optional = true }
 serde_bare = { version = "0.5.0", optional = true }
 serde_cbor = { version = "0.11.2", optional = true }
-serde_json = { version = "1.0.108", optional = true }
+serde_json = { version = "1.0.108", features = ["float_roundtrip"], optional = true }
 simd-json = { version = "0.13.4", optional = true }
 simd-json-derive = { version = "0.13.0", optional = true }
 speedy = { version = "0.8.6", optional = true }

--- a/src/bench_abomonation.rs
+++ b/src/bench_abomonation.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, Criterion};
 
 pub fn bench<T, R>(name: &'static str, c: &mut Criterion, data: &T, read: R)
 where
-    T: Abomonation + Clone,
+    T: Abomonation + Clone + PartialEq,
     R: Fn(&T),
 {
     const BUFFER_LEN: usize = 10_000_000;
@@ -48,6 +48,13 @@ where
     });
 
     crate::bench_size(name, "abomonation", deserialize_buffer.as_slice());
+
+    assert!(
+        unsafe { decode::<T>(black_box(&mut deserialize_buffer)) }
+            .unwrap()
+            .0
+            == data
+    );
 
     group.finish();
 }

--- a/src/bench_bincode.rs
+++ b/src/bench_bincode.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, Criterion};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: bincode::Encode + bincode::Decode,
+    T: bincode::Encode + bincode::Decode + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
     let mut group = c.benchmark_group(format!("{}/bincode", name));
@@ -31,6 +31,13 @@ where
     });
 
     crate::bench_size(name, "bincode", buffer);
+
+    assert!(
+        bincode::decode_from_slice::<T, _>(black_box(buffer), conf)
+            .unwrap()
+            .0
+            == *data
+    );
 
     group.finish();
 }

--- a/src/bench_bincode1.rs
+++ b/src/bench_bincode1.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "bincode1", deserialize_buffer.as_slice());
+
+    assert!(bincode1::deserialize::<'_, T>(black_box(&deserialize_buffer)).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_bitcode.rs
+++ b/src/bench_bitcode.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, Criterion};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Encode + DecodeOwned,
+    T: Encode + DecodeOwned + PartialEq,
 {
     let mut group = c.benchmark_group(format!("{}/bitcode", name));
     let mut buffer = bitcode::EncodeBuffer::<T>::default();
@@ -24,6 +24,8 @@ where
     });
 
     crate::bench_size(name, "bitcode", encoded);
+
+    assert!(buffer.decode(&encoded).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_borsh.rs
+++ b/src/bench_borsh.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, Criterion};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: BorshSerialize + BorshDeserialize,
+    T: BorshSerialize + BorshDeserialize + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -27,6 +27,8 @@ where
     });
 
     crate::bench_size(name, "borsh", deserialize_buffer.as_slice());
+
+    assert!(T::deserialize(&mut deserialize_buffer.as_slice()).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_bson.rs
+++ b/src/bench_bson.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -30,6 +30,8 @@ where
     });
 
     crate::bench_size(name, "bson", deserialize_buffer.as_slice());
+
+    assert!(bson::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_cbor4ii.rs
+++ b/src/bench_cbor4ii.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "cbor4ii", deserialize_buffer.as_slice());
+
+    assert!(cbor4ii::serde::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_ciborium.rs
+++ b/src/bench_ciborium.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -34,6 +34,8 @@ where
     });
 
     crate::bench_size(name, "ciborium", deserialize_buffer.as_slice());
+
+    assert!(ciborium::de::from_reader::<T, _>(deserialize_buffer.as_slice()).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_databuf.rs
+++ b/src/bench_databuf.rs
@@ -3,7 +3,7 @@ use databuf::{config::num::LE, *};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Encode + for<'de> Decode<'de>,
+    T: Encode + for<'de> Decode<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -26,6 +26,8 @@ where
     });
 
     crate::bench_size(name, "databuf", deserialize_buffer.as_slice());
+
+    assert!(T::from_bytes::<LE>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_dlhn.rs
+++ b/src/bench_dlhn.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -38,6 +38,14 @@ where
     });
 
     crate::bench_size(name, "dlhn", deserialize_buffer.as_slice());
+
+    assert!(
+        <T>::deserialize(&mut dlhn::de::Deserializer::new(
+            &mut deserialize_buffer.as_slice()
+        ))
+        .unwrap()
+            == *data
+    );
 
     group.finish();
 }

--- a/src/bench_msgpacker.rs
+++ b/src/bench_msgpacker.rs
@@ -4,7 +4,7 @@ use msgpacker::prelude::*;
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Packable + Unpackable,
+    T: Packable + Unpackable + PartialEq,
     <T as Unpackable>::Error: fmt::Debug,
 {
     const BUFFER_LEN: usize = 10_000_000;
@@ -29,6 +29,8 @@ where
     });
 
     crate::bench_size(name, "msgpacker", &deserialize_buffer);
+
+    assert!(T::unpack(&deserialize_buffer).unwrap().1 == *data);
 
     group.finish();
 }

--- a/src/bench_nachricht_serde.rs
+++ b/src/bench_nachricht_serde.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 25_000_000;
 
@@ -31,6 +31,8 @@ where
     });
 
     crate::bench_size(name, "nachricht-serde", deserialize_buffer.as_slice());
+
+    assert!(nachricht_serde::from_bytes::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_nanoserde.rs
+++ b/src/bench_nanoserde.rs
@@ -3,7 +3,7 @@ use nanoserde::{DeBin, SerBin};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: DeBin + SerBin,
+    T: DeBin + SerBin + PartialEq,
 {
     let mut group = c.benchmark_group(format!("{}/nanoserde", name));
 
@@ -23,6 +23,8 @@ where
     });
 
     crate::bench_size(name, "nanoserde", deserialize_buffer.as_slice());
+
+    assert!(<T as DeBin>::deserialize_bin(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_parity_scale_codec.rs
+++ b/src/bench_parity_scale_codec.rs
@@ -3,7 +3,7 @@ use parity_scale_codec::{Decode, Encode};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Encode + Decode,
+    T: Encode + Decode + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -26,6 +26,8 @@ where
     });
 
     crate::bench_size(name, "parity-scale-codec", deserialize_buffer.as_slice());
+
+    assert!(T::decode(&mut deserialize_buffer.as_slice()).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_postcard.rs
+++ b/src/bench_postcard.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "postcard", deserialize_buffer.as_slice());
+
+    assert!(postcard::from_bytes::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_pot.rs
+++ b/src/bench_pot.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 70_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "pot", deserialize_buffer.as_slice());
+
+    assert!(pot::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_prost.rs
+++ b/src/bench_prost.rs
@@ -45,7 +45,7 @@ where
 
     crate::bench_size(name, "prost", deserialize_buffer.as_slice());
 
-    assert!(&<T::Message>::decode(&*deserialize_buffer).unwrap().into() == data);
+    assert!(<T::Message>::decode(&*deserialize_buffer).unwrap().into() == *data);
 
     group.finish();
 }

--- a/src/bench_rmp_serde.rs
+++ b/src/bench_rmp_serde.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -31,6 +31,8 @@ where
     });
 
     crate::bench_size(name, "rmp-serde", deserialize_buffer.as_slice());
+
+    assert!(rmp_serde::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_ron.rs
+++ b/src/bench_ron.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "ron", deserialize_buffer.as_slice());
+
+    assert!(ron::de::from_bytes::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_savefile.rs
+++ b/src/bench_savefile.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + Deserialize + WithSchema,
+    T: Serialize + Deserialize + WithSchema + PartialEq,
 {
     let mut group = c.benchmark_group(format!("{}/savefile", name));
 
@@ -28,6 +28,10 @@ where
     });
 
     crate::bench_size(name, "savefile", deserialize_buffer.as_slice());
+
+    assert!(
+        savefile::load_noschema::<T>(&mut Cursor::new(&deserialize_buffer), 0).unwrap() == *data
+    );
 
     group.finish();
 }

--- a/src/bench_serde_bare.rs
+++ b/src/bench_serde_bare.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "serde_bare", deserialize_buffer.as_slice());
+
+    assert!(serde_bare::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_serde_cbor.rs
+++ b/src/bench_serde_cbor.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "serde_cbor", deserialize_buffer.as_slice());
+
+    assert!(serde_cbor::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_serde_json.rs
+++ b/src/bench_serde_json.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -28,6 +28,8 @@ where
     });
 
     crate::bench_size(name, "serde_json", deserialize_buffer.as_slice());
+
+    assert!(serde_json::from_slice::<T>(&deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }

--- a/src/bench_simd_json.rs
+++ b/src/bench_simd_json.rs
@@ -4,7 +4,7 @@ use simd_json_derive::{Deserialize, Serialize};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Serialize + for<'de> Deserialize<'de>,
+    T: Serialize + for<'de> Deserialize<'de> + PartialEq,
 {
     const BUFFER_LEN: usize = 50_000_000;
 
@@ -37,6 +37,12 @@ where
     });
 
     crate::bench_size(name, "simd-json", deserialize_buffer.as_slice());
+
+    assert!(
+        T::from_slice_with_buffers(deserialize_buffer.clone().as_mut_slice(), &mut buffers)
+            .unwrap()
+            == *data
+    );
 
     group.finish();
 }

--- a/src/bench_speedy.rs
+++ b/src/bench_speedy.rs
@@ -3,7 +3,7 @@ use speedy::{Endianness, Readable, Writable};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: for<'a> Readable<'a, Endianness> + Writable<Endianness>,
+    T: for<'a> Readable<'a, Endianness> + Writable<Endianness> + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 
@@ -35,6 +35,8 @@ where
     });
 
     crate::bench_size(name, "speedy", deserialize_buffer.as_slice());
+
+    assert!(T::read_from_buffer_with_ctx(CONTEXT, &deserialize_buffer).unwrap() == *data);
 
     group.finish();
 }


### PR DESCRIPTION
This adds checks validating that each of the serializers benchmarked (with the exception of some of the zero-copy ones that have less obvious routes back to the original struct type).

we also enable "float_roundtrip" in serde_json to make it pass the test; operating without this feature is a tripping hazard, and i feel like "actually the numbers can just be whatever" isn't a good scope for benchmarking without explicitly setting out to target that use case. frankly i'm kind of appalled that it's not default.