### PR TITLE
Pin deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ cargo_metadata = "0.15"
 clap = "4"
 enum-iterator = "0.8"
 fixed-map = { version = "0.9", default-features = false }
-regex = "1.9"
+regex = "1.10"
 schema = { path = "tools/schema" }
 serde = "1.0"
 serde_json = "1.0"
 stylist = { version = "0.12", default-features = false }
-tempfile = "3.6"
+tempfile = "3.10"
 time = "0.3"
 wasm-bindgen = "0.2"
-web-sys = "0.3.60"
+web-sys = "0.3.69"
 yew = { version = "0.20", default-features = false }
 
 [package]
@@ -43,56 +43,56 @@ build = "build.rs"
 # Some features may require multiple dependencies to compile properly
 # For example, benchmarking bincode requires two features: "serde" and "bincode"
 [dependencies]
-abomonation = { version = "0.7.3", optional = true }
-abomonation_derive = { version = "0.5.0", optional = true }
-alkahest = { version = "0.1.5", optional = true, features = [
+abomonation = { version = "=0.7.3", optional = true }
+abomonation_derive = { version = "=0.5.0", optional = true }
+alkahest = { version = "=0.1.5", optional = true, features = [
   "derive",
   "nightly",
 ] }
-bebop = { version = "2.4.9", optional = true }
-bilrost = { version = "0.1005.1", optional = true }
-bincode1 = { package = "bincode", version = "1.3.3", optional = true }
+bebop = { version = "=2.8.7", optional = true }
+bilrost = { version = "=0.1005.1", optional = true }
+bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2
-bincode = { package = "bincode", version = "2.0.0-rc", optional = true }
-bitcode = { version = "0.6.0", optional = true }
-borsh = { version = "1.1.1", features = ["derive"], optional = true }
+bincode = { package = "bincode", version = "=2.0.0-rc.3", optional = true }
+bitcode = { version = "=0.6.0", optional = true }
+borsh = { version = "=1.3.1", features = ["derive"], optional = true }
 # TODO: Unfork after bson adds support for pre-warmed serialization buffers
 # https://github.com/mongodb/bson-rust/pull/328
-bson = { version = "2.9.0", git = "https://github.com/djkoloski/bson-rust", branch = "add_into_vec", optional = true }
-bytecheck = { version = "0.6.11", optional = true }
-bytemuck = { version = "1.14.0", optional = true }
-capnp = { version = "0.18.3", optional = true }
-cbor4ii = { version = "0.3.1", features = [ "use_std", "serde1" ], optional = true }
-ciborium = { version = "0.2.1", optional = true }
-criterion = "0.5"
-databuf = { version = "0.5", optional = true }
-dlhn = { version = "0.1.6", optional = true }
-flatbuffers = { version = "23.5.26", optional = true }
-libflate = "1.3.0"
-msgpacker = { version = "0.4.3", optional = true }
-nachricht-serde = { version = "0.4.0", optional = true }
-nanoserde = {version = "0.1.35", optional = true }
-parity-scale-codec = { version = "3.6.5", features = ["full"], optional = true }
-parity-scale-codec-derive = { version = "3.6.5", optional = true }
-postcard = { version = "1.0.8", features = ["alloc"], optional = true }
-pot = { version = "3.0.0", optional = true }
-pprof = { version = "0.13", features = ["flamegraph"], optional = true }
-prost = { version = "0.12.3", optional = true }
-rand = "0.8.5"
+bson = { version = "=2.9.0", git = "https://github.com/djkoloski/bson-rust", branch = "add_into_vec", optional = true }
+bytecheck = { version = "=0.6.12", optional = true }
+bytemuck = { version = "=1.14.1", optional = true }
+capnp = { version = "=0.18.13", optional = true }
+cbor4ii = { version = "=0.3.2", features = [ "use_std", "serde1" ], optional = true }
+ciborium = { version = "=0.2.2", optional = true }
+criterion = "=0.5.1"
+databuf = { version = "=0.5", optional = true }
+dlhn = { version = "=0.1.6", optional = true }
+flatbuffers = { version = "=23.5.26", optional = true }
+libflate = "=1.4.0"
+msgpacker = { version = "=0.4.3", optional = true }
+nachricht-serde = { version = "=0.4.0", optional = true }
+nanoserde = {version = "=0.1.37", optional = true }
+parity-scale-codec = { version = "=3.6.9", features = ["full"], optional = true }
+parity-scale-codec-derive = { version = "=3.6.9", optional = true }
+postcard = { version = "=1.0.8", features = ["alloc"], optional = true }
+pot = { version = "=3.0.0", optional = true }
+pprof = { version = "=0.13.0", features = ["flamegraph"], optional = true }
+prost = { version = "=0.12.4", optional = true }
+rand = "=0.8.5"
 # TODO: unfork after rkyv updates to 0.8 or `stdsimd` cfg for nightly in aHash 0.7 is fixed
-rkyv = { version = "0.7.44", git = "https://github.com/rkyv/rkyv", branch = "0.7-hashbrown-0.14", features = ["validation"], optional = true }
-rmp-serde = { version = "1.1.2", optional = true }
-ron = { version = "0.8.1", optional = true }
-serde = { version = "1.0.190", features = ["derive"], optional = true }
-serde_bare = { version = "0.5.0", optional = true }
-serde_cbor = { version = "0.11.2", optional = true }
-serde_json = { version = "1.0.108", features = ["float_roundtrip"], optional = true }
-simd-json = { version = "0.13.4", optional = true }
-simd-json-derive = { version = "0.13.0", optional = true }
-speedy = { version = "0.8.6", optional = true }
-savefile = { version = "0.16.2", optional = true }
-savefile-derive = { version = "0.16.2", optional = true }
-zstd = "0.12.3"
+rkyv = { version = "=0.7.44", git = "https://github.com/rkyv/rkyv", branch = "0.7-hashbrown-0.14", features = ["validation"], optional = true }
+rmp-serde = { version = "=1.1.2", optional = true }
+ron = { version = "=0.8.1", optional = true }
+serde = { version = "=1.0.196", features = ["derive"], optional = true }
+serde_bare = { version = "=0.5.0", optional = true }
+serde_cbor = { version = "=0.11.2", optional = true }
+serde_json = { version = "=1.0.115", features = ["float_roundtrip"], optional = true }
+simd-json = { version = "=0.13.9", optional = true }
+simd-json-derive = { version = "=0.13.0", optional = true }
+speedy = { version = "=0.8.7", optional = true }
+savefile = { version = "=0.16.5", optional = true }
+savefile-derive = { version = "=0.16.5", optional = true }
+zstd = "=0.12.4"
 
 [features]
 default = [
@@ -147,11 +147,11 @@ regenerate-prost = ["dep:prost-build"]
 rand_pcg = "0.3.1"
 
 [build-dependencies]
-bebop-tools = "2.8.7"
-capnp = "0.18.3"
-capnpc = { version = "0.18.0", optional = true }
-flatc-rust = { version = "0.2.0", optional = true }
-prost-build = { version = "0.12.3", optional = true }
+bebop-tools = "=2.8.7"
+capnp = "=0.18.13"
+capnpc = { version = "=0.18.1", optional = true }
+flatc-rust = { version = "=0.2.0", optional = true }
+prost-build = { version = "=0.12.4", optional = true }
 
 [[bench]]
 harness = false


### PR DESCRIPTION
(This PR is dependent upon #72. Only the last commit in this PR does the thing.)

This does not change the version of any of the dependencies as they would be resolved in a fresh repo now. it does avoid newly published versions of upstream crates breaking things, like changing the generated files in prost-build or updating performance characteristics without changing the api.

Just as importantly, this actually causes the contents of Cargo.toml to accurately reflect the versions of the dependencies that are resolved, which shows some some pretty significant drift in the version numbers in a lot of these cases.

Probably the best way to check for outdated dependencies here is `cargo oudated --depth 1`, with "cargo-outdated" installed. Performing that task before updating the benchmarks seems like a reasonable addition to the workflow and can make tracking the provenance of these performance numbers a lot easier.

Of course the goal here is to make maintaining and updating the repo and tracking what's going on with it easier, and if you as the maintainer don't think it serves that purpose then :woman_shrugging: :put_litter_in_its_place: :smile:. I just reckon this seems like a probable improvement.