### PR TITLE
bench action: no codegen, but run lscpu

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,17 +47,7 @@ jobs:
         shell: bash
         run: |
 
-          wget "https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-linux-x86_64.zip" -O protoc.zip
-          unzip protoc.zip
-          chmod +x bin/protoc
-          mv bin/protoc /usr/local/bin
-
-          wget "https://github.com/google/flatbuffers/releases/download/v23.5.26/Linux.flatc.binary.clang++-12.zip" -O flatbuffers
-          unzip flatbuffers
-          chmod +x flatc
-          mv flatc /usr/local/bin
-
-          sudo apt-get install -y capnproto libprotobuf-dev
+          lscpu
 
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com


### PR DESCRIPTION
it is no longer necessary to fetch codegen tools, as they are no longer needed by default since 1a92464a3d39be45cf5b96af55f211991f70359e

however, at the level these libraries often operate, the runtime CPU matters. github actions' hosting infrastructure is pretty mysterious, so maybe we can pull the veil back a little bit

(i'm seeing regressions in the bilrost "prepend" path for a couple of these benchmarks; this is nothing new, it's actually amazing how much of the modern software & hardware stack seemingly revolves around the assumption that nobody does this)