### PR TITLE
fix: bump `wiring` to `0.2.2` and move it back to benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ simd-json-derive = { version = "=0.13.0", optional = true }
 speedy = { version = "=0.8.7", optional = true }
 savefile = { version = "=0.17.6", optional = true }
 savefile-derive = { version = "=0.17.6", optional = true }
-wiring = { version = "=0.2.1", optional = true }
+wiring = { version = "=0.2.2", optional = true }
 zstd = "=0.13.2"
 
 [features]
@@ -127,7 +127,7 @@ default = [
   "simd-json",
   "speedy",
   "savefile",
-  # "wiring" # does not build: slice_flatten is being stabilized and has been renamed
+  "wiring"
 ]
 capnp = ["dep:capnp"]
 prost = ["dep:capnp", "dep:prost"]


### PR DESCRIPTION
`wiring` is already updated by it maintainer and the benchmark can be compiled with `wiring` again