### PR TITLE
bilrost 0.1012

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ build = "build.rs"
 # Some features may require multiple dependencies to compile properly
 # For example, benchmarking bincode requires two features: "serde" and "bincode"
 [dependencies]
-bilrost = { version = "=0.1011.0", optional = true }
+bilrost = { version = "=0.1012.1", optional = true }
 bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2
 bincode = { package = "bincode", version = "=2.0.0-rc.3", optional = true }

--- a/src/bench_bilrost.rs
+++ b/src/bench_bilrost.rs
@@ -1,11 +1,11 @@
 use bilrost::buf::ReverseBuffer;
 use bilrost::bytes::BufMut;
-use bilrost::Message;
+use bilrost::OwnedMessage;
 use criterion::{black_box, Criterion};
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
-    T: Message + PartialEq,
+    T: OwnedMessage + PartialEq,
 {
     const BUFFER_LEN: usize = 10_000_000;
 


### PR DESCRIPTION
This upgrades the `bilrost` library to the latest release and demonstrates one new(ly public (ish)) feature that grants a large speed-up in the log benchmark.

As discussed, this does not actually benchmark borrowed decoding, which is also implemented in 0.1012; that's cheating. I'll see if I can look into how easy it might be to generalize that across benches later on.