### PR TITLE
bilrost must update to 0.1012.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ build = "build.rs"
 # Some features may require multiple dependencies to compile properly
 # For example, benchmarking bincode requires two features: "serde" and "bincode"
 [dependencies]
-bilrost = { version = "=0.1012.1", optional = true }
+bilrost = { version = "=0.1012.2", optional = true }
 bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2
 bincode = { package = "bincode", version = "=2.0.0-rc.3", optional = true }


### PR DESCRIPTION
i yanked some prior releases for an unrelated bug. the `=` version-pinning in rust_serialization_benchmark means this should at least be updated here.