### PR TITLE
Upgrade bitcode to 0.6.4 to resolve build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bilrost = { version = "=0.1012.2", optional = true }
 bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2
 bincode = { package = "bincode", version = "=2.0.0-rc.3", optional = true }
-bitcode = { version = "=0.6.3", optional = true }
+bitcode = { version = "=0.6.4", optional = true }
 borsh = { version = "=1.5.3", features = ["derive"], optional = true }
 capnp = { version = "=0.20.3", optional = true }
 cbor4ii = { version = "=0.3.3", features = [


### PR DESCRIPTION
`bitcode` 0.6.4 was released along with `bitcode_derive` 0.6.4.
We are pinning to `bitcode` 0.6.3 but it ends up using `bitcode_derive` 0.6.4, and fails due to incompatibility.
Probably worth fixing better on the `bitcode` side when compatibility changes, but for now let's just bump to `bitcode 0.6.4.