### PR TITLE
Fix protobuf methods gated incorrectly with prost feature

### DIFF
--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -2119,7 +2119,7 @@ impl bench_protobuf::Serialize for Players {
     }
 }
 
-#[cfg(feature = "prost")]
+#[cfg(feature = "protobuf")]
 impl From<rpb::minecraft_savedata::Players> for Players {
     fn from(value: rpb::minecraft_savedata::Players) -> Self {
         Players {

--- a/src/datasets/mk48/mod.rs
+++ b/src/datasets/mk48/mod.rs
@@ -1168,7 +1168,7 @@ impl bench_protobuf::Serialize for Update {
     }
 }
 
-#[cfg(feature = "prost")]
+#[cfg(feature = "protobuf")]
 impl From<rpb::mk48::Update> for Update {
     fn from(value: rpb::mk48::Update) -> Self {
         Update {


### PR DESCRIPTION
When commenting out `protobuf` from `default-encoding-set` we noticed I missed updating 2 methods when I worked on the protobuf impl.