### PR TITLE
fix bincode versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ enum-iterator = "0.8"
 fixed-map = { version = "0.9", default-features = false }
 regex = "1.11"
 schema = { path = "tools/schema" }
+semver = "1.0.26"
 serde = "1.0"
 serde_json = "1.0"
 stylist = { version = "0.12", default-features = false }

--- a/tools/bencher/src/main.rs
+++ b/tools/bencher/src/main.rs
@@ -32,13 +32,13 @@ fn main() {
 
     let mut bench_path = PathBuf::from("benchmark_results");
     bench_path.push(format!(
-        "{}-{}-{}_{}-{}-{}",
-        now.year(),
-        now.month() as usize,
-        now.day(),
-        now.hour(),
-        now.minute(),
-        now.second(),
+        "{yr}-{mon:02}-{day:02}_{hr:02}-{min:02}-{sec:02}",
+        yr = now.year(),
+        mon = now.month() as usize,
+        day = now.day(),
+        hr = now.hour(),
+        min = now.minute(),
+        sec = now.second(),
     ));
 
     let mut log_path = bench_path.clone();

--- a/tools/bencher/src/main.rs
+++ b/tools/bencher/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let metadata_path = NamedTempFile::new().unwrap().into_temp_path();
     let metadata = Command::new("cargo")
-        .args(["metadata"])
+        .args(["metadata", "--format-version", "1"])
         .output()
         .unwrap()
         .stdout;

--- a/tools/config.json
+++ b/tools/config.json
@@ -19,11 +19,11 @@
     "features": {
         "bincode1": {
             "name": "bincode",
-            "version": "1.3.3"
+            "version": "1"
         },
         "bincode": {
             "name": "bincode",
-            "version": "2.0.0-rc"
+            "version": "2"
         }
     }
 }

--- a/tools/parser/Cargo.toml
+++ b/tools/parser/Cargo.toml
@@ -11,5 +11,6 @@ cargo_metadata.workspace = true
 clap = { workspace = true, features = ["derive"] }
 regex.workspace = true
 schema.workspace = true
+semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true


### PR DESCRIPTION
since bincode2 is actually updating now, we might as well clean up the versioning config a bit

previously we just hard-replaced the crate version with the version from the config, but we can instead use the `version` field in the config there as a semver version spec that constrains which versions of the crate each feature is talking about. this way each feature will know, for example, which major version of the `bincode` crate it is about, and the lookups can find the correct one in the cargo metadata info.