### PR TITLE
group and annotate libraries that target a common encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,12 @@ default-encoding-set = [
     # "wiring",
 ]
 
+# Grouped features for comparing different implementations for a specific encoding
+all-cbor = ["cbor4ii", "ciborium", "serde_cbor"]
+all-json = ["serde_json", "simd-json"]
+all-messagepack = ["msgpacker", "rmp-serde"]
+all-protobuf = ["prost", "protobuf"]
+
 measure-compression = []
 capnp = ["dep:capnp"]
 prost = ["dep:prost", "dep:capnp"]

--- a/src/bench_nanoserde.rs
+++ b/src/bench_nanoserde.rs
@@ -29,4 +29,7 @@ where
     group.finish();
 }
 
+// TODO: nanoserde implements json & ron encodings as well as the binary encoding, so we could
+//  benchmark those as well.
+
 // nanoserde does not appear to support borrowed decoding.

--- a/tools/config.json
+++ b/tools/config.json
@@ -27,8 +27,6 @@
         }
     },
     "equivalent_encodings": {
-        "bincode1": "bincode",
-        "bincode": "bincode",
         "cbor4ii": "cbor",
         "ciborium": "cbor",
         "msgpacker": "messagepack",

--- a/tools/config.json
+++ b/tools/config.json
@@ -16,7 +16,7 @@
         }
     },
     "do_not_edit": "<!-- AUTOMATICALLY GENERATED, DO NOT EDIT -->\n<!-- edit README.md.template instead -->",
-    "features": {
+    "crate_matching": {
         "bincode1": {
             "name": "bincode",
             "version": "1"
@@ -25,5 +25,19 @@
             "name": "bincode",
             "version": "2"
         }
+    },
+    "equivalent_encodings": {
+        "bincode1": "bincode",
+        "bincode": "bincode",
+        "cbor4ii": "cbor",
+        "ciborium": "cbor",
+        "msgpacker": "messagepack",
+        "parity-scale-codec": "scale",
+        "prost": "protobuf",
+        "protobuf": "protobuf",
+        "rmp-serde": "messagepack",
+        "serde_cbor": "cbor",
+        "serde_json": "json",
+        "simd-json": "json"
     }
 }

--- a/tools/config.json
+++ b/tools/config.json
@@ -15,7 +15,7 @@
             "description": "This data set is composed of mk48.io game updates that contain data with many exploitable patterns and invariants."
         }
     },
-    "do_not_edit": "<!-- AUTOMATICALLY GENERATED, DO NOT EDIT -->\n<!-- edit README.md.template instead -->",
+    "do_not_edit_message": "<!-- AUTOMATICALLY GENERATED, DO NOT EDIT -->\n<!-- edit README.md.template instead -->",
     "crate_matching": {
         "bincode1": {
             "name": "bincode",

--- a/tools/config.json
+++ b/tools/config.json
@@ -18,15 +18,15 @@
     "do_not_edit_message": "<!-- AUTOMATICALLY GENERATED, DO NOT EDIT -->\n<!-- edit README.md.template instead -->",
     "crate_matching": {
         "bincode1": {
-            "name": "bincode",
+            "crate_name": "bincode",
             "version": "1"
         },
         "bincode": {
-            "name": "bincode",
+            "crate_name": "bincode",
             "version": "2"
         }
     },
-    "equivalent_encodings": {
+    "common_encodings": {
         "cbor4ii": "cbor",
         "ciborium": "cbor",
         "msgpacker": "messagepack",

--- a/tools/formatter/src/main.rs
+++ b/tools/formatter/src/main.rs
@@ -108,7 +108,7 @@ fn write_crate_row(
         write!(
             output,
             "| {encoding}:<br> [{pkg} {version}][{feature}] |",
-            pkg = package_id.name,
+            pkg = package_id.crate_name,
             version = package_id.version,
             feature = feature.name,
         )
@@ -116,7 +116,7 @@ fn write_crate_row(
         write!(
             output,
             "| [{pkg} {version}][{feature}] |",
-            pkg = package_id.name,
+            pkg = package_id.crate_name,
             version = package_id.version,
             feature = feature.name,
         )

--- a/tools/formatter/src/main.rs
+++ b/tools/formatter/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::Parser;
 
-use schema::{Bench, Config, Dataset, Features, Results, Values};
+use schema::{Bench, Config, Dataset, FeatureName, Features, Results, Values};
 
 #[derive(Parser, Debug)]
 #[command(name = "formatter")]
@@ -98,13 +98,29 @@ fn format_values<T: Copy, U: Display>(
     Ok(())
 }
 
-fn write_crate_row(output: &mut String, feature: &str, features: &Features) -> fmt::Result {
-    let package_id = features.get(feature).unwrap();
-    write!(
-        output,
-        "| [{} {}][{feature}] |",
-        package_id.name, package_id.version
-    )
+fn write_crate_row(
+    output: &mut String,
+    feature: FeatureName<'_>,
+    features: &Features,
+) -> fmt::Result {
+    let package_id = features.get(feature.name).unwrap();
+    if let Some(encoding) = feature.common_encoding {
+        write!(
+            output,
+            "| {encoding}:<br> [{pkg} {version}][{feature}] |",
+            pkg = package_id.name,
+            version = package_id.version,
+            feature = feature.name,
+        )
+    } else {
+        write!(
+            output,
+            "| [{pkg} {version}][{feature}] |",
+            pkg = package_id.name,
+            version = package_id.version,
+            feature = feature.name,
+        )
+    }
 }
 
 pub fn capitalize(s: &str) -> String {
@@ -123,6 +139,7 @@ pub fn capitalize(s: &str) -> String {
 fn build_tables(
     features: &Features,
     dataset: &Dataset,
+    config: &Config,
     columns: &[&str],
     placeholder: &str,
 ) -> Result<Tables, fmt::Error> {
@@ -155,7 +172,7 @@ fn build_tables(
         })
         .collect::<Vec<_>>();
 
-    for (feature, crate_) in dataset.features.iter() {
+    for (feature, crate_) in dataset.grouped_features(config) {
         if columns.iter().any(|&c| crate_.benches.contains_key(c)) {
             write_crate_row(&mut data, feature, features)?;
             write_crate_row(&mut comparison, feature, features)?;
@@ -241,8 +258,8 @@ fn format(
         {
             ser_de_cols.to_mut().retain(|&col| col != "borrow");
         }
-        let serde_tables = build_tables(&results.features, dataset, &ser_de_cols, "†")?;
-        let zcd_tables = build_tables(&results.features, dataset, ZCD_COLS, "‡")?;
+        let serde_tables = build_tables(&results.features, dataset, &config, &ser_de_cols, "†")?;
+        let zcd_tables = build_tables(&results.features, dataset, &config, ZCD_COLS, "‡")?;
 
         write!(
             &mut tables,

--- a/tools/formatter/src/main.rs
+++ b/tools/formatter/src/main.rs
@@ -322,7 +322,7 @@ fn format(
     }
 
     Ok(template
-        .replace("{dne}", &config.do_not_edit)
+        .replace("{dne}", &config.do_not_edit_message)
         .replace("{date}", date)
         .replace("{runtime_info}", &runtime_info)
         .replace("{tables}", &tables)

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
 }
 
 fn find_package_id(feature: &str, config: &Config, metadata: &Metadata) -> PackageId {
-    if let Some(package_id) = config.features.get(feature) {
+    if let Some(package_id) = config.crate_matching.get(feature) {
         PackageId {
             name: package_id.name.clone(),
             version: find_package_version(

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -116,9 +116,9 @@ fn main() {
 fn find_package_id(feature: &str, config: &Config, metadata: &Metadata) -> PackageId {
     if let Some(package_id) = config.crate_matching.get(feature) {
         PackageId {
-            name: package_id.name.clone(),
+            crate_name: package_id.crate_name.clone(),
             version: find_package_version(
-                &package_id.name,
+                &package_id.crate_name,
                 Some(
                     package_id
                         .version
@@ -130,7 +130,7 @@ fn find_package_id(feature: &str, config: &Config, metadata: &Metadata) -> Packa
         }
     } else {
         PackageId {
-            name: feature.to_string(),
+            crate_name: feature.to_string(),
             version: find_package_version(feature, None, metadata),
         }
     }

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -98,7 +98,10 @@ impl PartialOrd<Self> for FeatureName<'_> {
 impl Dataset {
     /// Groups features together with the given config, annotating them with the common encoding
     /// names from the config and returning a map that orders them according to that logic.
-    pub fn grouped_features<'a>(&'a self, config: &'a Config) -> BTreeMap<FeatureName<'a>, &'a Feature> {
+    pub fn grouped_features<'a>(
+        &'a self,
+        config: &'a Config,
+    ) -> BTreeMap<FeatureName<'a>, &'a Feature> {
         self.features
             .iter()
             .map(|(name, feature)| {

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -61,6 +61,8 @@ pub struct Dataset {
     pub features: BTreeMap<String, Feature>,
 }
 
+/// Represents the name of a benchmarked feature in the output, annotated with the name of the
+/// common encoding it implements if we know it.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct FeatureName<'a> {
     pub name: &'a str,
@@ -69,7 +71,10 @@ pub struct FeatureName<'a> {
 
 impl Ord for FeatureName<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Order first by
+        // Order by:
+        // 1. the common encoding (if we know it), falling back to the feature name
+        // 2. features that have a known common encoding come first
+        // 3. finally, within the same common encoding order by the feature name
         let this = (
             self.common_encoding.unwrap_or(self.name),
             self.common_encoding.is_none(),

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -7,13 +7,14 @@ use std::{
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct PackageId {
-    pub name: String,
+    #[serde(alias = "name")]
+    pub crate_name: String,
     pub version: String,
 }
 
 impl PackageId {
     pub fn crates_io_url(&self) -> String {
-        format!("https://crates.io/crates/{}/{}", self.name, self.version)
+        format!("https://crates.io/crates/{}/{}", self.crate_name, self.version)
     }
 }
 
@@ -37,7 +38,7 @@ pub struct Config {
     /// Information indicating which common encodings are implemented by the given libraries being
     /// benchmarked so that they can be compared side-by-side more directly; the keys are feature
     /// names and the values are names of common encodings
-    pub equivalent_encodings: HashMap<String, String>,
+    pub common_encodings: HashMap<String, String>,
 }
 
 impl Config {
@@ -108,7 +109,7 @@ impl Dataset {
                 (
                     FeatureName {
                         name: name.as_str(),
-                        common_encoding: config.equivalent_encodings.get(name).map(String::as_str),
+                        common_encoding: config.common_encodings.get(name).map(String::as_str),
                     },
                     feature,
                 )

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -30,7 +30,7 @@ pub struct Config {
     pub suites: HashMap<String, Suite>,
     /// Do-not-edit message inserted into the readme.md file warning contributors to modify the
     /// template instead
-    pub do_not_edit: String,
+    pub do_not_edit_message: String,
     /// Information for distinguishing the appropriate crate for benchmarks whose name doesn't match
     /// the name of the crate, perhaps because multiple versions of that crate are being benchmarked
     pub crate_matching: HashMap<String, PackageId>,

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::{
     collections::{BTreeMap, HashMap},
     path::Path,
@@ -25,9 +26,18 @@ pub struct Suite {
 
 #[derive(Deserialize, Serialize)]
 pub struct Config {
+    /// Benchmark suite information
     pub suites: HashMap<String, Suite>,
+    /// Do-not-edit message inserted into the readme.md file warning contributors to modify the
+    /// template instead
     pub do_not_edit: String,
-    pub features: HashMap<String, PackageId>,
+    /// Information for distinguishing the appropriate crate for benchmarks whose name doesn't match
+    /// the name of the crate, perhaps because multiple versions of that crate are being benchmarked
+    pub crate_matching: HashMap<String, PackageId>,
+    /// Information indicating which common encodings are implemented by the given libraries being
+    /// benchmarked so that they can be compared side-by-side more directly; the keys are feature
+    /// names and the values are names of common encodings
+    pub equivalent_encodings: HashMap<String, String>,
 }
 
 impl Config {
@@ -49,6 +59,54 @@ pub type Features = BTreeMap<String, PackageId>;
 #[derive(Default, Deserialize, Serialize)]
 pub struct Dataset {
     pub features: BTreeMap<String, Feature>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct FeatureName<'a> {
+    pub name: &'a str,
+    pub common_encoding: Option<&'a str>,
+}
+
+impl Ord for FeatureName<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Order first by
+        let this = (
+            self.common_encoding.unwrap_or(self.name),
+            self.common_encoding.is_none(),
+            self.name,
+        );
+        let that = (
+            other.common_encoding.unwrap_or(other.name),
+            other.common_encoding.is_none(),
+            other.name,
+        );
+        this.cmp(&that)
+    }
+}
+
+impl PartialOrd<Self> for FeatureName<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Dataset {
+    /// Groups features together with the given config, annotating them with the common encoding
+    /// names from the config and returning a map that orders them according to that logic.
+    pub fn grouped_features<'a>(&'a self, config: &'a Config) -> BTreeMap<FeatureName<'a>, &'a Feature> {
+        self.features
+            .iter()
+            .map(|(name, feature)| {
+                (
+                    FeatureName {
+                        name: name.as_str(),
+                        common_encoding: config.equivalent_encodings.get(name).map(String::as_str),
+                    },
+                    feature,
+                )
+            })
+            .collect()
+    }
 }
 
 #[derive(Default, Deserialize, Serialize)]

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -14,7 +14,10 @@ pub struct PackageId {
 
 impl PackageId {
     pub fn crates_io_url(&self) -> String {
-        format!("https://crates.io/crates/{}/{}", self.crate_name, self.version)
+        format!(
+            "https://crates.io/crates/{}/{}",
+            self.crate_name, self.version
+        )
     }
 }
 

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 use std::{
+    cmp::Ordering,
     collections::{BTreeMap, HashMap},
     path::Path,
 };


### PR DESCRIPTION
here's some logic I thought about to present the benchmarked libraries that target the same encoding (like json, cbor, protobuf etc.) more clearly, grouped together and clearly marked in the readme output. It looks like [this](https://github.com/djkoloski/rust_serialization_benchmark/commit/ff6efbfad9f49b4b6ba2e42c02085e3dd98d670c)

there's room to quibble about how this is presented; i just put like "json:\<br\>" before the crate in the first column of the table, but there's an argument to be made that maybe we could stick like a full-width table cell heading that just says "json" in it, though i'm not sure if that would really look better, and it doesn't seem like github flavored markdown supports merged cells anyway.