### PR TITLE
Add support for benchmarking nibblecode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ minicbor = { version = "=1.0.0", optional = true, features = [
 msgpacker = { version = "=0.4.8", optional = true }
 nachricht-serde = { version = "=0.4.0", optional = true }
 nanoserde = { version = "=0.2.1", optional = true }
+nibblecode = { version = "=0.1.0", optional = true }
 parity-scale-codec = { version = "=3.7.5", features = [
     "full",
 ], optional = true }
@@ -115,6 +116,7 @@ default-encoding-set = [
     "msgpacker",
     "nachricht-serde",
     "nanoserde",
+    "nibblecode",
     "postcard",
     "pot",
     "prost",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -31,6 +31,8 @@ use rust_serialization_benchmark::bench_msgpacker;
 use rust_serialization_benchmark::bench_nachricht_serde;
 #[cfg(feature = "nanoserde")]
 use rust_serialization_benchmark::bench_nanoserde;
+#[cfg(feature = "nibblecode")]
+use rust_serialization_benchmark::bench_nibblecode;
 #[cfg(feature = "scale")]
 use rust_serialization_benchmark::bench_parity_scale_codec;
 #[cfg(feature = "postcard")]
@@ -161,6 +163,30 @@ fn bench_log(c: &mut Criterion) {
 
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench_borrowable(BENCH, c, &data);
+
+    #[cfg(feature = "nibblecode")]
+    bench_nibblecode::bench(
+        BENCH,
+        c,
+        &data,
+        |logs| {
+            for log in logs.logs.iter() {
+                black_box(&log.address);
+                black_box(log.code);
+                black_box(log.size);
+            }
+        },
+        |log| {
+            for log in log.logs.iter_mut() {
+                log.address.x0 = 0;
+                log.address.x1 = 0;
+                log.address.x2 = 0;
+                log.address.x3 = 0;
+                log.code = 200.into();
+                log.size = 0.into();
+            }
+        },
+    );
 
     #[cfg(feature = "scale")]
     bench_parity_scale_codec::bench(BENCH, c, &data);
@@ -342,6 +368,25 @@ fn bench_mesh(c: &mut Criterion) {
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench(BENCH, c, &data);
 
+    #[cfg(feature = "nibblecode")]
+    bench_nibblecode::bench(
+        BENCH,
+        c,
+        &data,
+        |mesh| {
+            for triangle in mesh.triangles.iter() {
+                black_box(&triangle.normal);
+            }
+        },
+        |mesh| {
+            for triangle in mesh.triangles.iter_mut() {
+                triangle.normal.x = 0f32.into();
+                triangle.normal.y = 0f32.into();
+                triangle.normal.z = 0f32.into();
+            }
+        },
+    );
+
     #[cfg(feature = "scale")]
     bench_parity_scale_codec::bench(BENCH, c, &data);
 
@@ -515,6 +560,29 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
 
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench_borrowable(BENCH, c, &data);
+
+    #[cfg(feature = "nibblecode")]
+    bench_nibblecode::bench(
+        BENCH,
+        c,
+        &data,
+        |players| {
+            for player in players.players.iter() {
+                black_box(&player.game_type);
+            }
+        },
+        |players| {
+            use nibblecode::Serialize;
+            use rust_serialization_benchmark::datasets::minecraft_savedata::GameType;
+
+            for player in players.players.iter_mut() {
+                player.game_type = <GameType as Serialize>::Archived::Survival;
+                player.spawn_x = 0.into();
+                player.spawn_y = 0.into();
+                player.spawn_z = 0.into();
+            }
+        },
+    );
 
     #[cfg(feature = "scale")]
     bench_parity_scale_codec::bench(BENCH, c, &data);
@@ -692,6 +760,23 @@ fn bench_mk48(c: &mut Criterion) {
 
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench(BENCH, c, &data);
+
+    #[cfg(feature = "nibblecode")]
+    bench_nibblecode::bench(
+        BENCH,
+        c,
+        &data,
+        |updates| {
+            for update in updates.updates.iter() {
+                black_box(update.score);
+            }
+        },
+        |updates| {
+            for update in updates.updates.iter_mut() {
+                update.score *= 2;
+            }
+        },
+    );
 
     #[cfg(feature = "scale")]
     bench_parity_scale_codec::bench(BENCH, c, &data);

--- a/src/bench_nibblecode.rs
+++ b/src/bench_nibblecode.rs
@@ -1,0 +1,60 @@
+use criterion::{black_box, Criterion};
+use nibblecode::{
+    access, access_unchecked, access_unchecked_mut, aligned_alloc::new_uninit_boxed_slice,
+    to_bytes, to_bytes_in_unchecked, Serialize,
+};
+
+pub fn bench<T, R, U>(name: &'static str, c: &mut Criterion, data: &T, read: R, update: U)
+where
+    T: Serialize<Archived: PartialEq<T>> + PartialEq,
+    R: Fn(&T::Archived),
+    U: Fn(&mut T::Archived),
+{
+    let mut group = c.benchmark_group(format!("{}/nibblecode", name));
+
+    let mut buffer =
+        new_uninit_boxed_slice::<T>(data.serialized_size(size_of::<T::Archived>()).unwrap());
+
+    group.bench_function("serialize", |b| {
+        b.iter(|| {
+            black_box(unsafe { to_bytes_in_unchecked(black_box(data), black_box(&mut buffer)) })
+        })
+    });
+
+    let buffer = to_bytes(data).unwrap();
+
+    group.bench_function("access (unvalidated)", |b| {
+        b.iter(|| black_box(unsafe { access_unchecked::<T>(black_box(&*buffer)) }))
+    });
+
+    group.bench_function("access (validated upfront with error)", |b| {
+        b.iter(|| black_box(access::<T>(black_box(&buffer)).unwrap()))
+    });
+
+    group.bench_function("read (unvalidated)", |b| {
+        b.iter(|| {
+            let value = unsafe { access_unchecked::<T>(black_box(&*buffer)) };
+            read(value);
+        })
+    });
+
+    group.bench_function("read (validated upfront with error)", |b| {
+        b.iter(|| {
+            read(access::<T>(black_box(&*buffer)).unwrap());
+        })
+    });
+
+    let mut update_buffer = buffer.clone();
+    group.bench_function("update (unvalidated)", |b| {
+        b.iter(|| {
+            let value = unsafe { access_unchecked_mut::<T>(black_box(&mut *update_buffer)) };
+            update(value);
+        })
+    });
+
+    crate::bench_size(name, "nibblecode", &buffer);
+
+    assert!(access::<T>(buffer.as_ref()).unwrap() == data);
+
+    group.finish();
+}

--- a/src/datasets/log/mod.rs
+++ b/src/datasets/log/mod.rs
@@ -43,6 +43,8 @@ use crate::Generate;
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeAddress, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -224,6 +226,8 @@ impl From<log_protobuf::log::Address> for Address {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeLog, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -496,6 +500,8 @@ impl From<log_protobuf::log::Log> for Log {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeLogs, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/src/datasets/mesh/mod.rs
+++ b/src/datasets/mesh/mod.rs
@@ -43,6 +43,8 @@ use crate::Generate;
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeVector3, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -163,6 +165,8 @@ impl From<mesh_protobuf::mesh::Vector3> for Vector3 {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeTriangle, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -297,6 +301,8 @@ impl From<mesh_protobuf::mesh::Triangle> for Triangle {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeMesh, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -48,6 +48,8 @@ use crate::{generate_vec, Generate};
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeGameType, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -183,6 +185,8 @@ impl From<rpb::minecraft_savedata::GameType> for GameType {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeItem, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -367,6 +371,8 @@ impl From<rpb::minecraft_savedata::Item> for Item {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeAbilities, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -527,6 +533,8 @@ impl From<rpb::minecraft_savedata::Abilities> for Abilities {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeEntity, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -980,6 +988,8 @@ impl From<rpb::minecraft_savedata::Entity> for Entity {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeRecipeBook, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -1299,6 +1309,8 @@ impl From<rpb::minecraft_savedata::RecipeBook> for RecipeBook {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodePlayer, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -1994,6 +2006,8 @@ impl From<rpb::minecraft_savedata::Player> for Player {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodePlayers, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/src/datasets/mk48/mod.rs
+++ b/src/datasets/mk48/mod.rs
@@ -47,6 +47,8 @@ use crate::{generate_vec, Generate};
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeEntityType, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -324,6 +326,8 @@ fn generate_velocity(rng: &mut impl Rng) -> i16 {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeTransform, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -481,6 +485,8 @@ impl From<rpb::mk48::Transform> for Transform {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeGuidance, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -601,6 +607,8 @@ impl From<rpb::mk48::Guidance> for Guidance {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeContact, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -859,6 +867,8 @@ impl From<rpb::mk48::Contact> for Contact {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeTerrainUpdate, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -1019,6 +1029,8 @@ impl From<rpb::mk48::TerrainUpdate> for TerrainUpdate {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeUpdate, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -1191,6 +1203,8 @@ impl From<rpb::mk48::Update> for Update {
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
+#[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeUpdates, compare(PartialEq)))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // wiring causes this clippy lint everywhere
 #![cfg_attr(feature = "wiring", allow(clippy::manual_async_fn))]
+#![cfg_attr(feature = "nibblecode", feature(ptr_alignment_type))]
 
 #[cfg(feature = "bilrost")]
 pub mod bench_bilrost;
@@ -31,6 +32,8 @@ pub mod bench_msgpacker;
 pub mod bench_nachricht_serde;
 #[cfg(feature = "nanoserde")]
 pub mod bench_nanoserde;
+#[cfg(feature = "nibblecode")]
+pub mod bench_nibblecode;
 #[cfg(feature = "scale")]
 pub mod bench_parity_scale_codec;
 #[cfg(feature = "postcard")]


### PR DESCRIPTION
Adds support for benchmarking [nibblecode](https://github.com/bolshoytoster/nibblecode), a format inspired by rkyv, with sometimes better performance.