### PR TITLE
adds flexbuffers serde benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ ciborium = { version = "=0.2.2", optional = true }
 databuf = { version = "=0.5.0", optional = true }
 dlhn = { version = "=0.1.7", optional = true }
 flatbuffers = { version = "=25.2.10", optional = true }
+flexbuffers = { version = "=25.2.10", optional = true }
 minicbor = { version = "=1.0.0", optional = true, features = [
     "alloc",
     "derive",
@@ -112,6 +113,7 @@ default-encoding-set = [
     "databuf",
     "dlhn",
     "flatbuffers",
+    "flexbuffers",
     "minicbor",
     "msgpacker",
     "nachricht-serde",

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -158,7 +158,7 @@ fn bench_log(c: &mut Criterion) {
     );
 
     #[cfg(feature = "flexbuffers")]
-    bench_flexbuffers::bench(BENCH, c, &data);
+    bench_flexbuffers::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench_borrowable(BENCH, c, &data);
@@ -561,7 +561,7 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     );
 
     #[cfg(feature = "flexbuffers")]
-    bench_flexbuffers::bench(BENCH, c, &data);
+    bench_flexbuffers::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench_borrowable(BENCH, c, &data);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,6 +23,8 @@ use rust_serialization_benchmark::bench_databuf;
 use rust_serialization_benchmark::bench_dlhn;
 #[cfg(feature = "flatbuffers")]
 use rust_serialization_benchmark::bench_flatbuffers;
+#[cfg(feature = "flexbuffers")]
+use rust_serialization_benchmark::bench_flexbuffers;
 #[cfg(feature = "minicbor")]
 use rust_serialization_benchmark::bench_minicbor;
 #[cfg(feature = "msgpacker")]
@@ -154,6 +156,9 @@ fn bench_log(c: &mut Criterion) {
             }
         },
     );
+
+    #[cfg(feature = "flexbuffers")]
+    bench_flexbuffers::bench(BENCH, c, &data);
 
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench_borrowable(BENCH, c, &data);
@@ -359,6 +364,9 @@ fn bench_mesh(c: &mut Criterion) {
         },
     );
 
+    #[cfg(feature = "flexbuffers")]
+    bench_flexbuffers::bench(BENCH, c, &data);
+
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench(BENCH, c, &data);
 
@@ -551,6 +559,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
             }
         },
     );
+
+    #[cfg(feature = "flexbuffers")]
+    bench_flexbuffers::bench(BENCH, c, &data);
 
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench_borrowable(BENCH, c, &data);
@@ -751,6 +762,9 @@ fn bench_mk48(c: &mut Criterion) {
             }
         },
     );
+
+    #[cfg(feature = "flexbuffers")]
+    bench_flexbuffers::bench(BENCH, c, &data);
 
     #[cfg(feature = "minicbor")]
     bench_minicbor::bench(BENCH, c, &data);

--- a/src/bench_flexbuffers.rs
+++ b/src/bench_flexbuffers.rs
@@ -13,7 +13,7 @@ where
         b.iter(|| {
             black_box(&mut builder).reset();
             data.serialize(&mut builder).unwrap();
-            black_box(builder);
+            black_box(());
         })
     });
 

--- a/src/bench_flexbuffers.rs
+++ b/src/bench_flexbuffers.rs
@@ -1,3 +1,4 @@
+use crate::datasets::BorrowableData;
 use criterion::{black_box, Criterion};
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +35,47 @@ where
     });
 
     crate::bench_size(name, "flexbuffers", deserialize_buffer);
+
+    group.finish();
+}
+
+pub fn bench_borrowable<T>(name: &'static str, c: &mut Criterion, data: &T)
+where
+    T: BorrowableData + Serialize + for<'de> Deserialize<'de>,
+    for<'a> T::Borrowed<'a>: Serialize + Deserialize<'a>,
+{
+    bench(name, c, data);
+
+    let mut group = c.benchmark_group(format!("{}/flexbuffers", name));
+
+    let mut builder = flexbuffers::FlexbufferSerializer::new();
+    data.serialize(&mut builder).unwrap();
+    let bdata = T::Borrowed::from(data);
+
+    // The borrowed variant type should encode exactly the same as the owned type.
+    let mut borrowed_builder = flexbuffers::FlexbufferSerializer::new();
+    bdata.serialize(&mut borrowed_builder).unwrap();
+    assert_eq!(builder.view(), borrowed_builder.view());
+
+    let deserialize_buffer = builder.view();
+
+    // The borrowed value we decode should be equivalent to the input
+    assert!(
+        T::Borrowed::<'_>::deserialize(flexbuffers::Reader::get_root(deserialize_buffer).unwrap())
+            .unwrap()
+            == bdata
+    );
+
+    group.bench_function("borrow", |b| {
+        b.iter(|| {
+            black_box(
+                T::Borrowed::<'_>::deserialize(black_box(
+                    flexbuffers::Reader::get_root(black_box(deserialize_buffer)).unwrap(),
+                ))
+                .unwrap(),
+            );
+        });
+    });
 
     group.finish();
 }

--- a/src/bench_flexbuffers.rs
+++ b/src/bench_flexbuffers.rs
@@ -13,21 +13,27 @@ where
         b.iter(|| {
             black_box(&mut builder).reset();
             data.serialize(&mut builder).unwrap();
-            black_box(());
+            black_box(builder);
         })
     });
 
-    let buffer = builder.view();
+    builder.reset();
+    data.serialize(&mut builder).unwrap();
+
+    let deserialize_buffer = builder.view();
 
     group.bench_function("deserialize", |b| {
         b.iter(|| {
             black_box(
-                T::deserialize(black_box(flexbuffers::Reader::get_root(buffer).unwrap())).unwrap(),
+                T::deserialize(black_box(
+                    flexbuffers::Reader::get_root(black_box(deserialize_buffer)).unwrap(),
+                ))
+                .unwrap(),
             );
         })
     });
 
-    crate::bench_size(name, "flexbuffers", buffer);
+    crate::bench_size(name, "flexbuffers", deserialize_buffer);
 
     group.finish();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod bench_databuf;
 pub mod bench_dlhn;
 #[cfg(feature = "flatbuffers")]
 pub mod bench_flatbuffers;
+#[cfg(feature = "flexbuffers")]
+pub mod bench_flexbuffers;
 #[cfg(feature = "minicbor")]
 pub mod bench_minicbor;
 #[cfg(feature = "msgpacker")]


### PR DESCRIPTION
This PR adds the schema-less FlatBuffer companion FlexBuffers to the benchmark. 

Used the `src/bench_flatbuffers` and `src/bench_serde_json` as reference. Happy to make any changes to better conform to the existing benches.

Tested with `cargo bench --bench bench --no-default-features --features flexbuffers,pprof,measure-compression`