### PR TITLE
Implement minecraft savedata benchmark for bin-proto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ build = "build.rs"
 # For example, benchmarking bincode requires two features: "serde" and "bincode"
 [dependencies]
 bilrost = { version = "=0.1013.0", optional = true }
-bin-proto = { version = "=0.12.2", optional = true }
+bin-proto = { version = "=0.12.3", features = ["prepend-tags"], optional = true }
 bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2 (TODO: issue link?)
 bincode = { package = "bincode", version = "=2.0.1", optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -513,6 +513,9 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     #[cfg(feature = "bilrost")]
     bench_bilrost::bench_borrowable(BENCH, c, &data);
 
+    #[cfg(feature = "bin-proto")]
+    bench_bin_proto::bench(BENCH, c, &data);
+
     #[cfg(feature = "bincode1")]
     bench_bincode1::bench_borrowable(BENCH, c, &data);
 

--- a/src/datasets/log/mod.rs
+++ b/src/datasets/log/mod.rs
@@ -256,16 +256,12 @@ impl From<log_protobuf::log::Address> for Address {
 pub struct Log {
     #[cfg_attr(feature = "minicbor", n(0))]
     pub address: Address,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.identity.len()))]
     #[cfg_attr(feature = "minicbor", b(1))]
     pub identity: String,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.userid.len()))]
     #[cfg_attr(feature = "minicbor", b(2))]
     pub userid: String,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.date.len()))]
     #[cfg_attr(feature = "minicbor", b(3))]
     pub date: String,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.request.len()))]
     #[cfg_attr(feature = "minicbor", b(4))]
     pub request: String,
     #[cfg_attr(feature = "wiring", fixed)]
@@ -539,7 +535,6 @@ impl From<log_protobuf::log::Log> for Log {
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 pub struct Logs {
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.logs.len()))]
     #[cfg_attr(feature = "minicbor", n(0))]
     pub logs: Vec<Log>,
 }

--- a/src/datasets/mesh/mod.rs
+++ b/src/datasets/mesh/mod.rs
@@ -335,7 +335,6 @@ impl From<mesh_protobuf::mesh::Triangle> for Triangle {
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 pub struct Mesh {
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.triangles.len()))]
     #[cfg_attr(feature = "minicbor", n(0))]
     #[cfg_attr(
         feature = "wincode",

--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -37,6 +37,11 @@ use crate::{generate_vec, Generate};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Enumeration))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode),
+    bin_proto(discriminant_type = u8),
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -73,15 +78,19 @@ use crate::{generate_vec, Generate};
 #[repr(u8)]
 pub enum GameType {
     #[cfg_attr(feature = "bilrost", bilrost(0))]
+    #[cfg_attr(feature = "bin-proto", bin_proto(discriminant = 0))]
     #[cfg_attr(feature = "minicbor", n(0))]
     Survival,
     #[cfg_attr(feature = "bilrost", bilrost(1))]
+    #[cfg_attr(feature = "bin-proto", bin_proto(discriminant = 1))]
     #[cfg_attr(feature = "minicbor", n(1))]
     Creative,
     #[cfg_attr(feature = "bilrost", bilrost(2))]
+    #[cfg_attr(feature = "bin-proto", bin_proto(discriminant = 2))]
     #[cfg_attr(feature = "minicbor", n(2))]
     Adventure,
     #[cfg_attr(feature = "bilrost", bilrost(3))]
+    #[cfg_attr(feature = "bin-proto", bin_proto(discriminant = 3))]
     #[cfg_attr(feature = "minicbor", n(3))]
     Spectator,
 }
@@ -179,6 +188,10 @@ impl From<rpb::minecraft_savedata::GameType> for GameType {
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -367,6 +380,10 @@ impl From<rpb::minecraft_savedata::Item> for Item {
 
 #[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -530,6 +547,10 @@ impl From<rpb::minecraft_savedata::Abilities> for Abilities {
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -987,6 +1008,10 @@ impl From<rpb::minecraft_savedata::Entity> for Entity {
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -1310,6 +1335,10 @@ impl From<rpb::minecraft_savedata::RecipeBook> for RecipeBook {
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
@@ -2000,6 +2029,10 @@ impl From<rpb::minecraft_savedata::Player> for Player {
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[cfg_attr(
+    feature = "bin-proto",
+    derive(bin_proto::BitEncode, bin_proto::BitDecode)
+)]
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(

--- a/src/datasets/mk48/mod.rs
+++ b/src/datasets/mk48/mod.rs
@@ -666,22 +666,18 @@ pub struct Contact {
     pub damage: u8,
     #[cfg_attr(feature = "minicbor", n(1))]
     pub entity_id: u32,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = bool, tag_value = self.entity_type.is_some()))]
     #[cfg_attr(feature = "minicbor", n(2))]
     pub entity_type: Option<EntityType>,
     #[cfg_attr(feature = "minicbor", n(3))]
     pub guidance: Guidance,
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = bool, tag_value = self.player_id.is_some()))]
     #[cfg_attr(feature = "minicbor", n(4))]
     pub player_id: Option<u16>,
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.reloads.len()))]
     #[cfg_attr(feature = "minicbor", n(5))]
     pub reloads: Vec<bool>,
     #[cfg_attr(feature = "minicbor", n(6))]
     pub transform: Transform,
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.turret_angles.len()))]
     #[cfg_attr(feature = "minicbor", n(7))]
     pub turret_angles: Vec<u16>,
 }
@@ -933,7 +929,6 @@ pub struct TerrainUpdate {
     #[cfg_attr(feature = "minicbor", n(0))]
     chunk_id: (i8, i8),
     #[cfg_attr(feature = "bilrost", bilrost(encoding = "plainbytes"))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.data.len()))]
     #[cfg_attr(feature = "minicbor", n(1))]
     data: Vec<u8>,
 }
@@ -1098,7 +1093,6 @@ impl From<rpb::mk48::TerrainUpdate> for TerrainUpdate {
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 pub struct Update {
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.contacts.len()))]
     #[cfg_attr(feature = "minicbor", n(0))]
     pub contacts: Vec<Contact>,
     #[cfg_attr(feature = "wiring", fixed(2))]
@@ -1107,7 +1101,6 @@ pub struct Update {
     #[cfg_attr(feature = "minicbor", n(2))]
     pub world_radius: f32,
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.terrain_updates.len()))]
     #[cfg_attr(feature = "minicbor", n(3))]
     pub terrain_updates: Vec<TerrainUpdate>,
 }
@@ -1279,7 +1272,6 @@ impl From<rpb::mk48::Update> for Update {
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 pub struct Updates {
     #[cfg_attr(feature = "bilrost", bilrost(encoding(packed)))]
-    #[cfg_attr(feature = "bin-proto", bin_proto(tag_type = usize, tag_value = self.updates.len()))]
     #[cfg_attr(feature = "minicbor", n(0))]
     pub updates: Vec<Update>,
 }


### PR DESCRIPTION
Following the discussion here (#116), this PR implements the minecraft savedata benchmark for bin-proto.

It would be a good idea to document what the official stance is on skipping certain datasets, and if this is allowed, whether it should be pointed out in the readme.