### PR TITLE
Add maintainer attribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
 edition = "2021"
 license = "MIT"
 publish = false
@@ -34,7 +33,6 @@ yew = { version = "0.20", default-features = false }
 [package]
 name = "rust_serialization_benchmark"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/pages/Cargo.toml
+++ b/pages/Cargo.toml
@@ -3,7 +3,6 @@ cargo-features = ["panic-immediate-abort"]
 [package]
 name = "pages"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/tools/README.md.template
+++ b/tools/README.md.template
@@ -5,6 +5,14 @@
 The goal of these benchmarks is to provide thorough and complete benchmarks for various rust
 serialization frameworks.
 
+## Maintainers
+
+These benchmarks are maintained by a small group of volunteers. Special thanks to:
+
+- [djkoloski](https://github.com/djkoloski)
+- [mumbleskates](https://github.com/mumbleskates)
+- [finnbear](https://github.com/finnbear)
+
 ## These benchmarks are a work in progress
 
 These benchmarks are still being developed and pull requests to improve benchmarks are welcome.

--- a/tools/bencher/Cargo.toml
+++ b/tools/bencher/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "bencher"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/tools/formatter/Cargo.toml
+++ b/tools/formatter/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "formatter"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/tools/parser/Cargo.toml
+++ b/tools/parser/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "parser"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/tools/schema/Cargo.toml
+++ b/tools/schema/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "schema"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true


### PR DESCRIPTION
These benchmarks have far outgrown me, and I've had the good fortune to meet other highly-capable people who are willing to help maintain these benchmarks as well.

This commit removes the `author` field on all packages and adds a list of maintainers to the README.