### PR TITLE
Read values instead of references in zero-copy read benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -122,7 +122,14 @@ fn bench_log(c: &mut Criterion) {
             .unwrap();
         for log in data.get_logs().unwrap().iter() {
             let addr = log.get_address().unwrap();
-            black_box((addr.get_x0(), addr.get_x1(), addr.get_x2(), addr.get_x3(), log.get_code(), log.get_size()));
+            black_box((
+                addr.get_x0(),
+                addr.get_x1(),
+                addr.get_x2(),
+                addr.get_x3(),
+                log.get_code(),
+                log.get_size(),
+            ));
         }
     });
 
@@ -152,7 +159,14 @@ fn bench_log(c: &mut Criterion) {
             >(bytes);
             for log in data.logs().iter() {
                 let addr = log.address().unwrap();
-                black_box((addr.x0(), addr.x1(), addr.x2(), addr.x3(), log.code(), log.size()));
+                black_box((
+                    addr.x0(),
+                    addr.x1(),
+                    addr.x2(),
+                    addr.x3(),
+                    log.code(),
+                    log.size(),
+                ));
             }
         },
         |bytes| {
@@ -161,7 +175,14 @@ fn bench_log(c: &mut Criterion) {
                     .unwrap();
             for log in data.logs().iter() {
                 let addr = log.address().unwrap();
-                black_box((addr.x0(), addr.x1(), addr.x2(), addr.x3(), log.code(), log.size()));
+                black_box((
+                    addr.x0(),
+                    addr.x1(),
+                    addr.x2(),
+                    addr.x3(),
+                    log.code(),
+                    log.size(),
+                ));
             }
         },
     );
@@ -185,7 +206,14 @@ fn bench_log(c: &mut Criterion) {
         &data,
         |logs| {
             for log in logs.logs.iter() {
-                black_box((log.address.x0, log.address.x1, log.address.x2, log.address.x3, log.code, log.size));
+                black_box((
+                    log.address.x0,
+                    log.address.x1,
+                    log.address.x2,
+                    log.address.x3,
+                    log.code,
+                    log.size,
+                ));
             }
         },
         |log| {
@@ -222,7 +250,14 @@ fn bench_log(c: &mut Criterion) {
         &data,
         |logs| {
             for log in logs.logs.iter() {
-                black_box((log.address.x0, log.address.x1, log.address.x2, log.address.x3, log.code, log.size));
+                black_box((
+                    log.address.x0,
+                    log.address.x1,
+                    log.address.x2,
+                    log.address.x3,
+                    log.code,
+                    log.size,
+                ));
             }
         },
         |log| {


### PR DESCRIPTION
While doing a performance debug with Claude, it came to the opinion (I'm not smart enough) that many of the zero-copy "read" benchmarks aren't actually reading the data. They are determining the address of the data, and returning that to `blackbox` but not actually prompting a read. If you had to add up all of the read values, for example, it would do more work.

Claude-not-Frank produced a variety of edits to the frameworks that force a dereference. I know how to do this with `columnar` (PR coming soon) but I'm not personally certain for each of these frameworks. Might be best to check with them to confirm, or .. otherwise figure out (perhaps you all can read docs better than I can :D).

The relative slowdowns on my laptop were (good news for capnp, at least):
```
  ┌─────────────┬───────┬───────┬───────────┬───────┐
  │  Framework  │  log  │ mesh  │ minecraft │ mk48  │
  ├─────────────┼───────┼───────┼───────────┼───────┤
  │ capnp       │ 0.88x │ 0.94x │ ~same     │ ~same │
  ├─────────────┼───────┼───────┼───────────┼───────┤
  │ flatbuffers │ 1.08x │ 1.68x │ ~same     │ ~same │
  ├─────────────┼───────┼───────┼───────────┼───────┤
  │ nibblecode  │ 1.79x │ 2.59x │ ~same     │ ~same │
  ├─────────────┼───────┼───────┼───────────┼───────┤
  │ rkyv        │ 1.74x │ 2.47x │ ~same     │ ~same │
  └─────────────┴───────┴───────┴───────────┴───────┘
```