### PR TITLE
Remove core2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ build = "build.rs"
 # For example, benchmarking bincode requires two features: "serde" and "bincode"
 [dependencies]
 bilrost = { version = "=0.1013.0", optional = true }
-bin-proto = { version = "=0.12.3", features = ["prepend-tags"], optional = true }
+bin-proto = { version = "=0.12.7", features = ["prepend-tags"], optional = true }
 bincode1 = { package = "bincode", version = "=1.3.3", optional = true }
 # Can't call it bincode2 because of a current issue of bincode2 (TODO: issue link?)
 bincode = { package = "bincode", version = "=2.0.1", optional = true }
@@ -99,7 +99,7 @@ wiring = { version = "=0.2.4", optional = true }
 zerompk = { version = "=0.3.2", optional = true, features = ["derive"] }
 
 criterion = "=0.5.1"
-libflate = "=2.1.0"
+libflate = "=2.3.0"
 pprof = { version = "=0.14.0", features = ["flamegraph"], optional = true }
 rand = "=0.8.5"
 serde = { version = "=1.0.219", features = ["derive"] }


### PR DESCRIPTION
core2 has been deprecated in the most fun of ways. All releases have been yanked, meaning that if you don't have a lockfile checked into git, you're SOL and can't build.