### PR TITLE
feat: update msgpacker to version 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ minicbor = { version = "=1.0.0", optional = true, features = [
     "alloc",
     "derive",
 ] }
-msgpacker = { version = "=0.4.8", optional = true }
+msgpacker = { version = "=0.7.1", optional = true }
 nachricht-serde = { version = "=0.4.0", optional = true }
 nanoserde = { version = "=0.2.1", optional = true }
 nibblecode = { version = "=0.1.0", optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -187,7 +187,7 @@ fn bench_log(c: &mut Criterion) {
     bench_minicbor::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "msgpacker")]
-    bench_msgpacker::bench(BENCH, c, &data);
+    bench_msgpacker::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench_borrowable(BENCH, c, &data);
@@ -626,7 +626,7 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     bench_minicbor::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "msgpacker")]
-    bench_msgpacker::bench(BENCH, c, &data);
+    bench_msgpacker::bench_borrowable(BENCH, c, &data);
 
     #[cfg(feature = "nachricht-serde")]
     bench_nachricht_serde::bench_borrowable(BENCH, c, &data);

--- a/src/bench_msgpacker.rs
+++ b/src/bench_msgpacker.rs
@@ -1,38 +1,71 @@
 use core::fmt;
-use criterion::{black_box, BatchSize, Criterion};
-use msgpacker::prelude::*;
+use criterion::{black_box, Criterion};
+use msgpacker::{Encoder, EncoderSlice, Packable, Unpackable, UnpackableBorrowed};
+
+use crate::datasets::BorrowableData;
+
+const BUFFER_LEN: usize = 10_000_000;
 
 pub fn bench<T>(name: &'static str, c: &mut Criterion, data: &T)
 where
     T: Packable + Unpackable + PartialEq,
     <T as Unpackable>::Error: fmt::Debug,
 {
-    const BUFFER_LEN: usize = 10_000_000;
-
     let mut group = c.benchmark_group(format!("{}/msgpacker", name));
+    let mut encoder = Encoder::with_capacity(BUFFER_LEN);
+    T::pack(data, &mut encoder);
+    let mut buffer = encoder.into_inner();
+    let mut encoder = EncoderSlice::new(&mut buffer);
 
     group.bench_function("serialize", |b| {
-        b.iter_batched(
-            || Vec::with_capacity(BUFFER_LEN),
-            |mut buf| T::pack(black_box(data), &mut buf),
-            BatchSize::SmallInput,
-        );
+        b.iter(|| {
+            T::pack(black_box(data), black_box(&mut encoder));
+            encoder.reset();
+        });
     });
-
-    let mut deserialize_buffer = Vec::new();
-    T::pack(data, &mut deserialize_buffer);
 
     group.bench_function("deserialize", |b| {
         b.iter(|| {
-            T::unpack(black_box(&deserialize_buffer)).unwrap();
+            T::unpack(black_box(&buffer)).unwrap();
         })
     });
 
-    crate::bench_size(name, "msgpacker", &deserialize_buffer);
+    crate::bench_size(name, "msgpacker", &buffer);
 
-    assert!(T::unpack(&deserialize_buffer).unwrap().1 == *data);
+    // sanity check
+    assert!(T::unpack(&buffer).unwrap() == *data);
 
     group.finish();
 }
 
-// msgpacker does not seem to support borrowed decoding.
+pub fn bench_borrowable<T>(name: &'static str, c: &mut Criterion, data: &T)
+where
+    T: Packable + Unpackable + PartialEq + BorrowableData,
+    <T as Unpackable>::Error: fmt::Debug,
+    for<'a> T::Borrowed<'a>: Packable + UnpackableBorrowed<'a>,
+    for<'a> <T::Borrowed<'a> as UnpackableBorrowed<'a>>::Error: fmt::Debug,
+{
+    bench(name, c, data);
+
+    let mut group = c.benchmark_group(format!("{}/msgpacker", name));
+    let mut encoder = Encoder::with_capacity(BUFFER_LEN);
+    T::pack(data, &mut encoder);
+    let buffer = encoder.into_inner();
+
+    let bdata = T::Borrowed::from(data);
+
+    // The borrowed variant type should encode exactly the same as the owned type.
+    let borrowed_serialized = bdata.pack_to_vec();
+    assert_eq!(borrowed_serialized, buffer);
+
+    // The borrowed value we decode should be equivalent to the input
+    assert!(T::Borrowed::unpack(&buffer).unwrap() == bdata);
+
+    group.bench_function("borrow", |b| {
+        b.iter(|| {
+            black_box(T::Borrowed::unpack(black_box(&buffer)).unwrap());
+        })
+    });
+
+    group.finish();
+}

--- a/src/datasets/log/mod.rs
+++ b/src/datasets/log/mod.rs
@@ -46,7 +46,10 @@ use crate::Generate;
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeAddress, compare(PartialEq)))]
 #[cfg_attr(
@@ -291,6 +294,7 @@ pub struct Log {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
@@ -569,6 +573,7 @@ pub struct Logs {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]

--- a/src/datasets/mesh/mod.rs
+++ b/src/datasets/mesh/mod.rs
@@ -46,7 +46,10 @@ use crate::Generate;
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeVector3, compare(PartialEq)))]
 #[cfg_attr(
@@ -179,7 +182,10 @@ impl From<mesh_protobuf::mesh::Vector3> for Vector3 {
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeTriangle, compare(PartialEq)))]
 #[cfg_attr(

--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -52,7 +52,10 @@ use crate::{generate_vec, Generate};
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeGameType, compare(PartialEq)))]
 #[cfg_attr(
@@ -253,6 +256,7 @@ pub struct Item {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
@@ -412,7 +416,10 @@ impl From<rpb::minecraft_savedata::Item> for Item {
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeAbilities, compare(PartialEq)))]
 #[cfg_attr(
@@ -656,6 +663,7 @@ pub struct Entity {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
@@ -1117,6 +1125,7 @@ pub struct RecipeBook {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
@@ -1493,6 +1502,7 @@ pub struct Player {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
@@ -2140,6 +2150,7 @@ pub struct Players {
 #[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
+#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPackerBorrowed))]
 #[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "speedy", derive(speedy::Readable, speedy::Writable))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]

--- a/src/datasets/mk48/mod.rs
+++ b/src/datasets/mk48/mod.rs
@@ -51,7 +51,10 @@ use crate::{generate_vec, Generate};
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeEntityType, compare(PartialEq)))]
 #[cfg_attr(
@@ -355,7 +358,10 @@ fn generate_velocity(rng: &mut impl Rng) -> i16 {
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeTransform, compare(PartialEq)))]
 #[cfg_attr(
@@ -525,7 +531,10 @@ impl From<rpb::mk48::Transform> for Transform {
 #[cfg_attr(feature = "compactly", derive(compactly::Encode))]
 #[cfg_attr(feature = "databuf", derive(databuf::Encode, databuf::Decode))]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-#[cfg_attr(feature = "msgpacker", derive(msgpacker::MsgPacker))]
+#[cfg_attr(
+    feature = "msgpacker",
+    derive(msgpacker::MsgPacker, msgpacker::MsgUnpackerBorrowed)
+)]
 #[cfg_attr(feature = "nibblecode", derive(nibblecode::Serialize))]
 #[cfg_attr(feature = "nibblecode", nibblecode(archived = NibblecodeGuidance, compare(PartialEq)))]
 #[cfg_attr(
@@ -960,6 +969,7 @@ pub struct TerrainUpdate {
     chunk_id: (i8, i8),
     #[cfg_attr(feature = "bilrost", bilrost(encoding = "plainbytes"))]
     #[cfg_attr(feature = "minicbor", n(1))]
+    #[cfg_attr(feature = "msgpacker", msgpacker(binary))]
     data: Vec<u8>,
 }
 


### PR DESCRIPTION
The previous PR #134 had a problem where I don't call `encoder.reset` for each iteration, causing the buffer to indefinitely grow. While we likely should have a mechanism to see a problematic behavior of a benchmark, it might be out of scope to fix that on the current PR.

Closes #135 