### PR TITLE
feat: Add `capnp_packed` to the comparison

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -132,6 +132,20 @@ fn bench_log(c: &mut Criterion) {
         }
     });
 
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::log::cp::logs::Reader>()
+            .unwrap();
+        for log in data.get_logs().unwrap().iter() {
+            black_box(log.get_address().unwrap());
+            black_box(log.get_code());
+            black_box(log.get_size());
+        }
+    });
+
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench_borrowable(BENCH, c, &data);
 
@@ -361,6 +375,18 @@ fn bench_mesh(c: &mut Criterion) {
         }
     });
 
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::mesh::cp::mesh::Reader>()
+            .unwrap();
+        for triangle in data.get_triangles().unwrap().iter() {
+            black_box(triangle.get_normal().unwrap());
+        }
+    });
+
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench(BENCH, c, &data);
 
@@ -566,6 +592,18 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     bench_capnp::bench(BENCH, c, &data, |bytes| {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
+        let data = message_reader
+      .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
+      .unwrap();
+        for player in data.get_players().unwrap().iter() {
+            black_box(player.get_game_type().unwrap());
+        }
+    });
+
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
         let data = message_reader
       .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
       .unwrap();
@@ -789,6 +827,18 @@ fn bench_mk48(c: &mut Criterion) {
     bench_capnp::bench(BENCH, c, &data, |bytes| {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
+            .unwrap();
+        for update in data.get_updates().unwrap().iter() {
+            black_box(update.get_score());
+        }
+    });
+
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
         let data = message_reader
             .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
             .unwrap();

--- a/src/bench_capnp.rs
+++ b/src/bench_capnp.rs
@@ -62,5 +62,50 @@ where
     group.finish();
 }
 
+// Packed format: same wire schema, zero-byte runs stripped. Requires an unpack
+// step on decode, so it's not zero-copy — only `serialize` and `deserialize`
+// groups are emitted (no `access` / `read`), placing it in the ser/de table
+// alongside other conventional encoders.
+pub fn bench_packed<T, R>(name: &'static str, c: &mut Criterion, data: &T, read: R)
+where
+    T: for<'a> Serialize<'a>,
+    R: Fn(&mut &[u8]),
+{
+    const BUFFER_LEN: usize = 1_000_000;
+
+    let mut group = c.benchmark_group(format!("{}/capnp_packed", name));
+
+    let mut serialize_buffer = Vec::new();
+
+    let mut scratch_words = capnp::Word::allocate_zeroed_vec(BUFFER_LEN);
+    let mut allocator =
+        ScratchSpaceHeapAllocator::new(capnp::Word::words_to_bytes_mut(&mut scratch_words[..]));
+    group.bench_function("serialize", |b| {
+        b.iter(|| {
+            black_box(&mut serialize_buffer).clear();
+            let mut builder = capnp::message::Builder::new(&mut allocator);
+            data.serialize_capnp(&mut builder.init_root::<T::Builder>());
+            capnp::serialize_packed::write_message(&mut serialize_buffer, &builder).unwrap();
+            black_box(());
+        })
+    });
+
+    let mut deserialize_buffer = Vec::new();
+    let mut builder = capnp::message::Builder::new(&mut allocator);
+    data.serialize_capnp(&mut builder.init_root::<T::Builder>());
+    capnp::serialize_packed::write_message(&mut deserialize_buffer, &builder).unwrap();
+
+    group.bench_function("deserialize", |b| {
+        b.iter(|| {
+            read(black_box(&mut deserialize_buffer.as_slice()));
+            black_box(());
+        })
+    });
+
+    crate::bench_size(name, "capnp_packed", deserialize_buffer.as_slice());
+
+    group.finish();
+}
+
 // capnp is a pseudo-zerocopy library with incremental decoding and does not support borrowed
 // decoding.

--- a/tools/config.json
+++ b/tools/config.json
@@ -27,6 +27,8 @@
         }
     },
     "common_encodings": {
+        "capnp": "capnp",
+        "capnp_packed": "capnp",
         "cbor4ii": "cbor",
         "ciborium": "cbor",
         "serde_cbor": "cbor",


### PR DESCRIPTION
capnp offers "packed" version of the wire format - https://capnproto.org/encoding.html#packing

This PR adds such packed serialisation/deserialisation to the benchmark.

| Dataset | size (flat → packed) | zlib (flat → packed) | zstd (flat → packed) |
| --- | --- | --- | --- |
| log | 1,443,216 → 1,046,865 (−27%) | 513,986 → 481,681 (−6%) | 426,532 → 458,024 (+7%) |
| mesh | 14,000,088 → 10,401,737 (−26%) | 7,130,367 → 7,308,001 (+2%) | 6,046,182 → 7,922,110 (+31%) |
| minecraft_savedata | 803,896 → 489,017 (−39%) | 335,606 → 293,127 (−13%) | 280,744 → 271,528 (−3%) |
| mk48 | 2,724,288 → 1,616,255 (−41%) | 1,546,992 → 1,278,764 (−17%) | 1,239,111 → 1,125,654 (−9%) |