### PR TITLE
introduce encoding modes for capnp-packed

### DIFF
--- a/ADDING_BENCHMARKS.md
+++ b/ADDING_BENCHMARKS.md
@@ -1,0 +1,88 @@
+# How to add a library to the benchmarks
+
+## General organization
+
+The main benchmark binary is in `benches/bench.rs`, which calls into public
+sub-functions for each sub-benchmark in the crate lib.
+
+The benchmark functionalities for each associated crate live under
+`src/benchmark_*.rs`. Each library under test should have both its dependency
+and all of its associated code gated by a dedicated feature. The full set of
+libraries under test at any given time is set by the "default-encoding-set"
+feature in `Cargo.toml`.
+
+## Benchmark organization and naming
+
+The benchmarks generally are divided among four suites, the datasets that are
+seen in the README. Any new library should implement encoding & decoding as
+appropriate for the top level data types of these four suites
+(`datasets::log::Logs`, `datasets::mesh::Mesh`,
+`datasets::minecraft_savedata::Players`, and `datasets::mk48::Update`) and
+their subsidiary types. Most libraries can apply `derive`s to the appropriate
+structs, though others may need `From` impls to convert to their generated
+struct types.
+
+Individual benchmarks are named by the pattern: `{suite}/{feature}/{bench}`, or
+`{suite}/{feature}/{bench} ({variant})`. `{feature}` should almost always be
+the unambiguous name of the crate, and if it is not a line must be added to
+`tools/config.json` under `"crate_matching"` to clarify. (This is useful both
+when multiple versions of a crate are under test, such as `bincode`, and when
+a library has multiple modes that merit it appearing on multiple rows of the
+results, such as `capnp`.)
+
+If a library's encoding, decoding, etc. abilities have multiple modes the names
+of the appropriate benchmarks under its benchmarking group can be parenthesized
+with the `{variant}`: for example, `prost` tests encoding both with and without
+including the time to convert into the library's generated struct, `bilrost`
+can encode to different kinds of output buffers in different ways, and `rkyv`
+supports accessing the contents of an archived struct with or without full
+validation.
+
+## Benchmarks for implementations of common encodings
+
+Multiple different libraries may implement a common encoding, for example
+JSON or CBOR. When a library (or a specific benchmark "feature" group)
+implements a common encoding this way, it can be added to `tools/config.json`
+under `"common_encodings"`, which causes libraries that work with similar data
+encodings to be grouped together in the README tables.
+
+## Achievement standards
+
+There are a number of different things an encoding library may be able to do,
+which we generally compare in common columns of the results table in the
+README:
+
+* **"serialize"**: Given an input struct, encode the contents of that struct to a
+  string or byte buffer.
+* **"deserialize"**: The reverse process, decoding that same data *back* into the
+  same struct type (or the library's equivalent). The resulting data must be
+  equal to the value from the input.
+* **"borrow"**: Exactly the same as "deserialize", but with string data
+  referring to the data still in the input buffer rather than copying it to a
+  new allocation. The suites which have string data have corresponding struct
+  types that contain borrowed string data instead, and implement the trait
+  `datasets::BorrowableData` for this type association. For libraries which
+  naturally support decoding from borrowed data[^textborrow],
+* **"access"**: For zero-copy libraries, accessing a single field value inside
+  the input buffer, without necessarily validating that the whole structure is
+  valid and coherent.
+* **"read"**: For zero-copy libraries, read each the values from the struct
+  without necessarily creating an owned struct outside of the buffer being
+  decoded.
+* **"update"**: For zero-copy libraries, update some values in each of the
+  sub-structs encoded in a *mutable* buffer containing the encoded data.
+
+Output buffers may be preallocated and reused by the benchmarks.
+
+[textborrow]: Some serde-based text encodings can even support fallibly
+decoding borrowed strings; this may be possible in for example JSON when the
+text never contains escapes. For these purposes the strings in the benchmark
+suites should remain relatively simple, so it should be possible to benchmark
+these capabilities (as `serde_json` does).
+
+## Codegen
+
+Generated code used by the library, such as code created from protobuf files,
+should be regenerated at build time conditionally by feature. The generated
+code should be checked in and up to date, and will be regenenerated and checked
+for any changes in CI.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -132,6 +132,20 @@ fn bench_log(c: &mut Criterion) {
         }
     });
 
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::log::cp::logs::Reader>()
+            .unwrap();
+        for log in data.get_logs().unwrap().iter() {
+            black_box(log.get_address().unwrap());
+            black_box(log.get_code());
+            black_box(log.get_size());
+        }
+    });
+
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench_borrowable(BENCH, c, &data);
 
@@ -361,6 +375,18 @@ fn bench_mesh(c: &mut Criterion) {
         }
     });
 
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::mesh::cp::mesh::Reader>()
+            .unwrap();
+        for triangle in data.get_triangles().unwrap().iter() {
+            black_box(triangle.get_normal().unwrap());
+        }
+    });
+
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench(BENCH, c, &data);
 
@@ -567,8 +593,20 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
         let data = message_reader
-      .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
-      .unwrap();
+            .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
+            .unwrap();
+        for player in data.get_players().unwrap().iter() {
+            black_box(player.get_game_type().unwrap());
+        }
+    });
+
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
+            .unwrap();
         for player in data.get_players().unwrap().iter() {
             black_box(player.get_game_type().unwrap());
         }
@@ -789,6 +827,18 @@ fn bench_mk48(c: &mut Criterion) {
     bench_capnp::bench(BENCH, c, &data, |bytes| {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
+        let data = message_reader
+            .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
+            .unwrap();
+        for update in data.get_updates().unwrap().iter() {
+            black_box(update.get_score());
+        }
+    });
+
+    #[cfg(feature = "capnp")]
+    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
+        let message_reader =
+            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
         let data = message_reader
             .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
             .unwrap();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -132,20 +132,6 @@ fn bench_log(c: &mut Criterion) {
         }
     });
 
-    #[cfg(feature = "capnp")]
-    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
-        let message_reader =
-            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
-        let data = message_reader
-            .get_root::<rust_serialization_benchmark::datasets::log::cp::logs::Reader>()
-            .unwrap();
-        for log in data.get_logs().unwrap().iter() {
-            black_box(log.get_address().unwrap());
-            black_box(log.get_code());
-            black_box(log.get_size());
-        }
-    });
-
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench_borrowable(BENCH, c, &data);
 
@@ -375,18 +361,6 @@ fn bench_mesh(c: &mut Criterion) {
         }
     });
 
-    #[cfg(feature = "capnp")]
-    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
-        let message_reader =
-            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
-        let data = message_reader
-            .get_root::<rust_serialization_benchmark::datasets::mesh::cp::mesh::Reader>()
-            .unwrap();
-        for triangle in data.get_triangles().unwrap().iter() {
-            black_box(triangle.get_normal().unwrap());
-        }
-    });
-
     #[cfg(feature = "cbor4ii")]
     bench_cbor4ii::bench(BENCH, c, &data);
 
@@ -592,18 +566,6 @@ fn bench_minecraft_savedata(c: &mut Criterion) {
     bench_capnp::bench(BENCH, c, &data, |bytes| {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
-        let data = message_reader
-      .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
-      .unwrap();
-        for player in data.get_players().unwrap().iter() {
-            black_box(player.get_game_type().unwrap());
-        }
-    });
-
-    #[cfg(feature = "capnp")]
-    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
-        let message_reader =
-            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
         let data = message_reader
       .get_root::<rust_serialization_benchmark::datasets::minecraft_savedata::cp::players::Reader>()
       .unwrap();
@@ -827,18 +789,6 @@ fn bench_mk48(c: &mut Criterion) {
     bench_capnp::bench(BENCH, c, &data, |bytes| {
         let message_reader =
             capnp::serialize::read_message_from_flat_slice(bytes, Default::default()).unwrap();
-        let data = message_reader
-            .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
-            .unwrap();
-        for update in data.get_updates().unwrap().iter() {
-            black_box(update.get_score());
-        }
-    });
-
-    #[cfg(feature = "capnp")]
-    bench_capnp::bench_packed(BENCH, c, &data, |bytes| {
-        let message_reader =
-            capnp::serialize_packed::read_message(bytes, Default::default()).unwrap();
         let data = message_reader
             .get_root::<rust_serialization_benchmark::datasets::mk48::cp::updates::Reader>()
             .unwrap();

--- a/src/bench_capnp.rs
+++ b/src/bench_capnp.rs
@@ -60,20 +60,11 @@ where
     crate::bench_size(name, "capnp", deserialize_buffer.as_slice());
 
     group.finish();
-}
 
-// Packed format: same wire schema, zero-byte runs stripped. Requires an unpack
-// step on decode, so it's not zero-copy — only `serialize` and `deserialize`
-// groups are emitted (no `access` / `read`), placing it in the ser/de table
-// alongside other conventional encoders.
-pub fn bench_packed<T, R>(name: &'static str, c: &mut Criterion, data: &T, read: R)
-where
-    T: for<'a> Serialize<'a>,
-    R: Fn(&mut &[u8]),
-{
-    const BUFFER_LEN: usize = 1_000_000;
+    // -----------
+    // Also benchmark in "packed" mode
 
-    let mut group = c.benchmark_group(format!("{}/capnp_packed", name));
+    let mut group = c.benchmark_group(format!("{}/capnp__packed", name));
 
     let mut serialize_buffer = Vec::new();
 
@@ -102,7 +93,7 @@ where
         })
     });
 
-    crate::bench_size(name, "capnp_packed", deserialize_buffer.as_slice());
+    crate::bench_size(name, "capnp (packed)", deserialize_buffer.as_slice());
 
     group.finish();
 }

--- a/src/bench_capnp.rs
+++ b/src/bench_capnp.rs
@@ -60,9 +60,18 @@ where
     crate::bench_size(name, "capnp", deserialize_buffer.as_slice());
 
     group.finish();
+}
 
-    // -----------
-    // Also benchmark in "packed" mode
+// Packed format: same wire schema, zero-byte runs stripped. Requires an unpack
+// step on decode, so it's not zero-copy — only `serialize` and `deserialize`
+// groups are emitted (no `access` / `read`), placing it in the ser/de table
+// alongside other conventional encoders.
+pub fn bench_packed<T, R>(name: &'static str, c: &mut Criterion, data: &T, read: R)
+where
+    T: for<'a> Serialize<'a>,
+    R: Fn(&mut &[u8]),
+{
+    const BUFFER_LEN: usize = 1_000_000;
 
     let mut group = c.benchmark_group(format!("{}/capnp__packed", name));
 

--- a/src/bench_capnp.rs
+++ b/src/bench_capnp.rs
@@ -102,7 +102,7 @@ where
         })
     });
 
-    crate::bench_size(name, "capnp (packed)", deserialize_buffer.as_slice());
+    crate::bench_size(name, "capnp__packed", deserialize_buffer.as_slice());
 
     group.finish();
 }

--- a/tools/config.json
+++ b/tools/config.json
@@ -24,11 +24,16 @@
         "bincode": {
             "crate_name": "bincode",
             "version": "2"
+        },
+        "capnp__packed": {
+            "crate_name": "capnp",
+            "mode": "packed encoding",
+            "version": "*"
         }
     },
     "common_encodings": {
         "capnp": "capnp",
-        "capnp_packed": "capnp",
+        "capnp__packed": "capnp",
         "cbor4ii": "cbor",
         "ciborium": "cbor",
         "serde_cbor": "cbor",

--- a/tools/formatter/src/main.rs
+++ b/tools/formatter/src/main.rs
@@ -104,23 +104,23 @@ fn write_crate_row(
     features: &Features,
 ) -> fmt::Result {
     let package_id = features.get(feature.name).unwrap();
-    if let Some(encoding) = feature.common_encoding {
-        write!(
-            output,
-            "| {encoding}:<br> [{pkg} {version}][{feature}] |",
-            pkg = package_id.crate_name,
-            version = package_id.version,
-            feature = feature.name,
-        )
-    } else {
-        write!(
-            output,
-            "| [{pkg} {version}][{feature}] |",
-            pkg = package_id.crate_name,
-            version = package_id.version,
-            feature = feature.name,
-        )
-    }
+    write!(
+        output,
+        "| {encoding}[{pkg} {version}][{feature}]{mode} |",
+        encoding = if let Some(encoding) = &feature.common_encoding {
+            format!("{encoding}:<br> ")
+        } else {
+            String::new()
+        },
+        pkg = package_id.crate_name,
+        version = package_id.version,
+        feature = feature.name,
+        mode = if let Some(mode) = &package_id.mode {
+            format!(" (mode: {mode})")
+        } else {
+            String::new()
+        },
+    )
 }
 
 pub fn capitalize(s: &str) -> String {

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -47,10 +47,12 @@ fn main() {
         .map(|path| fs::read_to_string(path).unwrap());
 
     let time_benches_re = Regex::new(
-        r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/([a-z0-9_\-]+)(?: \(([a-z0-9_\-+ ]*)\))?\s+time:   \[\d+\.\d+ [µnm]s (\d+\.\d+ [µnm]s)"
+        r"(?m)^(?<suite>[a-z0-9_\-]+)\/(?<feature>[a-z0-9_\-]+)\/(?<bench>[a-z0-9_\-]+)(?: \((?<variant>[a-z0-9_\-+ ]*)\))?\s+time:   \[\d+\.\d+ [µnm]s (?<time>\d+\.\d+ [µnm]s)"
     ).unwrap();
-    let size_benches_re =
-        Regex::new(r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/(size|zlib|zstd) (\d+)").unwrap();
+    let size_benches_re = Regex::new(
+        r"(?m)^(?<dataset>[a-z0-9_\-]+)\/(?<feature>[a-z0-9_\-]+)\/(?<bench>size|zlib|zstd) (?<size>\d+)",
+    )
+    .unwrap();
 
     let mut results = Results {
         cpu_info,
@@ -59,22 +61,25 @@ fn main() {
     };
 
     for capture in time_benches_re.captures_iter(&log) {
-        let feature = &capture[2];
+        let feature = &capture["feature"];
         results
             .features
             .entry(feature.to_string())
             .or_insert_with(|| find_package_id(feature, &config, &metadata));
 
-        let dataset = results.datasets.entry(capture[1].to_string()).or_default();
+        let dataset = results
+            .datasets
+            .entry(capture["suite"].to_string())
+            .or_default();
         let package = dataset.features.entry(feature.to_string()).or_default();
         let bench = package
             .benches
-            .entry(capture[3].to_string())
+            .entry(capture["bench"].to_string())
             .or_insert(Bench::nanos());
         let values = bench.unwrap_nanos();
 
-        let value = parse_time(&capture[5]);
-        if let Some(variant) = capture.get(4) {
+        let value = parse_time(&capture["time"]);
+        if let Some(variant) = capture.name("variant") {
             values.variants.insert(variant.as_str().to_string(), value);
         } else {
             values.primary = Some(value);
@@ -82,20 +87,23 @@ fn main() {
     }
 
     for capture in size_benches_re.captures_iter(&log) {
-        let feature = &capture[2];
+        let feature = &capture["feature"];
         results
             .features
             .entry(feature.to_string())
             .or_insert_with(|| find_package_id(feature, &config, &metadata));
 
-        let dataset = results.datasets.entry(capture[1].to_string()).or_default();
+        let dataset = results
+            .datasets
+            .entry(capture["dataset"].to_string())
+            .or_default();
         let package = dataset.features.entry(feature.to_string()).or_default();
         let bench = package
             .benches
-            .entry(capture[3].to_string())
+            .entry(capture["bench"].to_string())
             .or_insert(Bench::bytes());
         let values = bench.unwrap_bytes();
-        values.primary = Some(capture[4].parse().unwrap());
+        values.primary = Some(capture["size"].parse().unwrap());
     }
 
     fs::write(args.output, serde_json::to_string(&results).unwrap()).unwrap();

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -113,6 +113,7 @@ fn find_package_id(feature: &str, config: &Config, metadata: &Metadata) -> Packa
     if let Some(package_id) = config.crate_matching.get(feature) {
         PackageId {
             crate_name: package_id.crate_name.clone(),
+            mode: package_id.mode.clone(),
             version: find_package_version(
                 &package_id.crate_name,
                 Some(
@@ -127,6 +128,7 @@ fn find_package_id(feature: &str, config: &Config, metadata: &Metadata) -> Packa
     } else {
         PackageId {
             crate_name: feature.to_string(),
+            mode: None,
             version: find_package_version(feature, None, metadata),
         }
     }

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -7,8 +7,12 @@ use std::{
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct PackageId {
+    /// Name of the actual crate that does the encoding
     #[serde(alias = "name")]
     pub crate_name: String,
+    /// Friendly encoding mode for this package variant
+    pub mode: Option<String>,
+    /// Semver version for the associated crate
     pub version: String,
 }
 


### PR DESCRIPTION
#140 failed to have any effect or even update the readme because the parser crashed during the actions step, because `capnp_packed` isn't a crate we depend on so this breaks the expectations of the benchmark output `parser`.

i've added a concept of a "mode" to the `PackageId` struct here so we can configure that e.g. `capnp__packed` means the `capnp` crate running in a particular mode. because its usability is functionally differently enough in "packed" mode, since realistically there's no way to get immediate access to single fields of the buffer, it sorta still makes enough sense to keep this as a separate row in the table probably.

this doesn't resolve the issue with our actions workflows, so we have to actually check every single one to see if it failed or not now, which sucks.

either way, i've tested this with benchmark output and manually running the parse & format tools until it does the right thing.