### PR TITLE
fix: capnp packed variant

### DIFF
--- a/src/bench_capnp.rs
+++ b/src/bench_capnp.rs
@@ -63,9 +63,9 @@ where
 }
 
 // Packed format: same wire schema, zero-byte runs stripped. Requires an unpack
-// step on decode, so it's not zero-copy — only `serialize` and `deserialize`
-// groups are emitted (no `access` / `read`), placing it in the ser/de table
-// alongside other conventional encoders.
+// step on decode, so it's not zero-copy. It's reported as `(packed)` variants of
+// the `capnp` benchmark — `serialize`/`deserialize` and size in the ser/de table
+// — rather than as a separate library row.
 pub fn bench_packed<T, R>(name: &'static str, c: &mut Criterion, data: &T, read: R)
 where
     T: for<'a> Serialize<'a>,
@@ -73,14 +73,14 @@ where
 {
     const BUFFER_LEN: usize = 1_000_000;
 
-    let mut group = c.benchmark_group(format!("{}/capnp_packed", name));
+    let mut group = c.benchmark_group(format!("{}/capnp", name));
 
     let mut serialize_buffer = Vec::new();
 
     let mut scratch_words = capnp::Word::allocate_zeroed_vec(BUFFER_LEN);
     let mut allocator =
         ScratchSpaceHeapAllocator::new(capnp::Word::words_to_bytes_mut(&mut scratch_words[..]));
-    group.bench_function("serialize", |b| {
+    group.bench_function("serialize (packed)", |b| {
         b.iter(|| {
             black_box(&mut serialize_buffer).clear();
             let mut builder = capnp::message::Builder::new(&mut allocator);
@@ -95,14 +95,14 @@ where
     data.serialize_capnp(&mut builder.init_root::<T::Builder>());
     capnp::serialize_packed::write_message(&mut deserialize_buffer, &builder).unwrap();
 
-    group.bench_function("deserialize", |b| {
+    group.bench_function("deserialize (packed)", |b| {
         b.iter(|| {
             read(black_box(&mut deserialize_buffer.as_slice()));
             black_box(());
         })
     });
 
-    crate::bench_size(name, "capnp_packed", deserialize_buffer.as_slice());
+    crate::bench_size_variant(name, "capnp", "packed", deserialize_buffer.as_slice());
 
     group.finish();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,15 +173,28 @@ pub fn generate_vec<R: Rng, T: Generate>(rng: &mut R, range: ops::Range<usize>) 
 }
 
 pub fn bench_size(name: &str, lib: &str, bytes: &[u8]) {
-    println!("{}/{}/size {}", name, lib, bytes.len());
+    bench_size_inner(name, lib, None, bytes);
+}
+
+/// Like [`bench_size`], but records the size under a named variant of `lib`
+/// (e.g. capnp's `packed` variant) instead of as the library's primary size,
+/// matching the `serialize (variant)` naming used for timed benchmarks.
+pub fn bench_size_variant(name: &str, lib: &str, variant: &str, bytes: &[u8]) {
+    bench_size_inner(name, lib, Some(variant), bytes);
+}
+
+fn bench_size_inner(name: &str, lib: &str, variant: Option<&str>, bytes: &[u8]) {
+    let suffix = variant.map(|v| format!(" ({v})")).unwrap_or_default();
+    println!("{}/{}/size{} {}", name, lib, suffix, bytes.len());
     #[cfg(feature = "measure-compression")]
     {
-        println!("{}/{}/zlib {}", name, lib, zlib_size(bytes));
-        println!("{}/{}/zstd {}", name, lib, zstd_size(bytes));
+        println!("{}/{}/zlib{} {}", name, lib, suffix, zlib_size(bytes));
+        println!("{}/{}/zstd{} {}", name, lib, suffix, zstd_size(bytes));
         println!(
-            "{}/{}/zstd_time {}",
+            "{}/{}/zstd_time{} {}",
             name,
             lib,
+            suffix,
             bench_compression(|| zstd_size(bytes))
         );
     }

--- a/tools/config.json
+++ b/tools/config.json
@@ -28,7 +28,6 @@
     },
     "common_encodings": {
         "capnp": "capnp",
-        "capnp_packed": "capnp",
         "cbor4ii": "cbor",
         "ciborium": "cbor",
         "serde_cbor": "cbor",

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -49,8 +49,10 @@ fn main() {
     let time_benches_re = Regex::new(
         r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/([a-z0-9_\-]+)(?: \(([a-z0-9_\-+ ]*)\))?\s+time:   \[\d+\.\d+ [µnm]s (\d+\.\d+ [µnm]s)"
     ).unwrap();
-    let size_benches_re =
-        Regex::new(r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/(size|zlib|zstd) (\d+)").unwrap();
+    let size_benches_re = Regex::new(
+        r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/(size|zlib|zstd)(?: \(([a-z0-9_\-+ ]*)\))? (\d+)",
+    )
+    .unwrap();
 
     let mut results = Results {
         cpu_info,
@@ -95,7 +97,13 @@ fn main() {
             .entry(capture[3].to_string())
             .or_insert(Bench::bytes());
         let values = bench.unwrap_bytes();
-        values.primary = Some(capture[4].parse().unwrap());
+
+        let value = capture[5].parse().unwrap();
+        if let Some(variant) = capture.get(4) {
+            values.variants.insert(variant.as_str().to_string(), value);
+        } else {
+            values.primary = Some(value);
+        }
     }
 
     fs::write(args.output, serde_json::to_string(&results).unwrap()).unwrap();

--- a/tools/parser/src/main.rs
+++ b/tools/parser/src/main.rs
@@ -47,10 +47,10 @@ fn main() {
         .map(|path| fs::read_to_string(path).unwrap());
 
     let time_benches_re = Regex::new(
-        r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/([a-z0-9_\-]+)(?: \(([a-z0-9_\-+ ]*)\))?\s+time:   \[\d+\.\d+ [µnm]s (\d+\.\d+ [µnm]s)"
+        r"(?m)^(?<suite>[a-z0-9_\-]+)\/(?<feature>[a-z0-9_\-]+)\/(?<bench>[a-z0-9_\-]+)(?: \((?<variant>[a-z0-9_\-+ ]*)\))?\s+time:   \[\d+\.\d+ [µnm]s (?<time>\d+\.\d+ [µnm]s)"
     ).unwrap();
     let size_benches_re = Regex::new(
-        r"(?m)^([a-z0-9_\-]+)\/([a-z0-9_\-]+)\/(size|zlib|zstd)(?: \(([a-z0-9_\-+ ]*)\))? (\d+)",
+        r"(?m)^(?<dataset>[a-z0-9_\-]+)\/(?<feature>[a-z0-9_\-]+)\/(?<bench>size|zlib|zstd)(?: \((?<variant>[a-z0-9_\-+ ]*)\))? (?<size>\d+)",
     )
     .unwrap();
 
@@ -61,22 +61,25 @@ fn main() {
     };
 
     for capture in time_benches_re.captures_iter(&log) {
-        let feature = &capture[2];
+        let feature = &capture["feature"];
         results
             .features
             .entry(feature.to_string())
             .or_insert_with(|| find_package_id(feature, &config, &metadata));
 
-        let dataset = results.datasets.entry(capture[1].to_string()).or_default();
+        let dataset = results
+            .datasets
+            .entry(capture["suite"].to_string())
+            .or_default();
         let package = dataset.features.entry(feature.to_string()).or_default();
         let bench = package
             .benches
-            .entry(capture[3].to_string())
+            .entry(capture["bench"].to_string())
             .or_insert(Bench::nanos());
         let values = bench.unwrap_nanos();
 
-        let value = parse_time(&capture[5]);
-        if let Some(variant) = capture.get(4) {
+        let value = parse_time(&capture["time"]);
+        if let Some(variant) = capture.name("variant") {
             values.variants.insert(variant.as_str().to_string(), value);
         } else {
             values.primary = Some(value);
@@ -84,22 +87,25 @@ fn main() {
     }
 
     for capture in size_benches_re.captures_iter(&log) {
-        let feature = &capture[2];
+        let feature = &capture["feature"];
         results
             .features
             .entry(feature.to_string())
             .or_insert_with(|| find_package_id(feature, &config, &metadata));
 
-        let dataset = results.datasets.entry(capture[1].to_string()).or_default();
+        let dataset = results
+            .datasets
+            .entry(capture["dataset"].to_string())
+            .or_default();
         let package = dataset.features.entry(feature.to_string()).or_default();
         let bench = package
             .benches
-            .entry(capture[3].to_string())
+            .entry(capture["bench"].to_string())
             .or_insert(Bench::bytes());
         let values = bench.unwrap_bytes();
 
-        let value = capture[5].parse().unwrap();
-        if let Some(variant) = capture.get(4) {
+        let value = capture["size"].parse().unwrap();
+        if let Some(variant) = capture.name("variant") {
             values.variants.insert(variant.as_str().to_string(), value);
         } else {
             values.primary = Some(value);


### PR DESCRIPTION
#140 added "packed" variant to the benchmark, but as was mentioned in https://github.com/djkoloski/rust_serialization_benchmark/pull/140#issuecomment-4755425806, parser expects as if `capnp_packed` crate existed. 

This PR changes it to "packed" variant for capnp crate.