### PR TITLE
Update compactly to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,7 @@ ciborium = { version = "=0.2.2", optional = true }
 columnar = { version = "=0.13.1", optional = true }
 # columnar doesn't properly pin its derive crate: https://github.com/frankmcsherry/columnar/issues/115
 columnar_derive = { version = "=0.13.1", optional = true }
-# TODO: compactly emits build-breaking deprecation warnings as of 0.1.8: https://github.com/droundy/compactly/issues/41
-compactly = { version = "=0.1.7", optional = true }
-# compactly doesn't properly pin its derive crate: https://github.com/droundy/compactly/issues/40
-compactly-derive = { version = "=0.1.7", optional = true }
+compactly = { version = "=0.2.0", optional = true }
 databuf = { version = "=0.5.0", optional = true }
 dlhn = { version = "=0.1.7", optional = true }
 flatbuffers = { version = "=25.12.19", optional = true }
@@ -177,7 +174,7 @@ measure-compression = []
 buffa = ["dep:buffa"]
 capnp = ["dep:capnp"]
 columnar = ["dep:columnar", "dep:columnar_derive"]
-compactly = ["dep:compactly", "dep:compactly-derive"]
+compactly = ["dep:compactly"]
 prost = ["dep:prost", "dep:capnp"]
 protobuf = ["dep:protobuf"]
 protobuf4 = ["dep:protobuf4", "dep:protobuf4-generated"]

--- a/src/datasets/log/mod.rs
+++ b/src/datasets/log/mod.rs
@@ -339,12 +339,12 @@ pub struct Log {
     #[cfg_attr(feature = "minicbor", b(1))]
     pub identity: String,
     #[cfg_attr(feature = "minicbor", b(2))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub userid: String,
     #[cfg_attr(feature = "minicbor", b(3))]
     pub date: String,
     #[cfg_attr(feature = "minicbor", b(4))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub request: String,
     #[cfg_attr(feature = "wiring", fixed)]
     #[cfg_attr(feature = "minicbor", n(5))]

--- a/src/datasets/minecraft_savedata/mod.rs
+++ b/src/datasets/minecraft_savedata/mod.rs
@@ -308,7 +308,7 @@ pub struct Item {
     #[cfg_attr(feature = "minicbor", n(1))]
     pub slot: u8,
     #[cfg_attr(feature = "minicbor", b(2))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub id: String,
 }
 
@@ -793,7 +793,7 @@ impl bench_protobuf4::Serialize for Abilities {
 )]
 pub struct Entity {
     #[cfg_attr(feature = "minicbor", b(0))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub id: String,
     #[cfg_attr(feature = "wiring", fixed(11))]
     #[cfg_attr(feature = "minicbor", n(1))]
@@ -820,7 +820,7 @@ pub struct Entity {
     #[cfg_attr(feature = "minicbor", n(11))]
     pub uuid: [u32; 4],
     #[cfg_attr(feature = "minicbor", n(12))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub custom_name: Option<String>,
     #[cfg_attr(feature = "wiring", fixed)]
     #[cfg_attr(feature = "minicbor", n(13))]
@@ -1866,14 +1866,14 @@ pub struct Player {
     #[cfg_attr(feature = "minicbor", n(2))]
     pub score: i64,
     #[cfg_attr(feature = "minicbor", b(3))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub dimension: String,
     #[cfg_attr(feature = "minicbor", b(4))]
     pub selected_item_slot: u32,
     #[cfg_attr(feature = "minicbor", n(5))]
     pub selected_item: Item,
     #[cfg_attr(feature = "minicbor", b(6))]
-    #[cfg_attr(feature = "compactly", compactly(LowCardinality))]
+    #[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
     pub spawn_dimension: Option<String>,
     #[cfg_attr(feature = "wiring", fixed(3))]
     #[cfg_attr(feature = "minicbor", n(7))]


### PR DESCRIPTION
Updates `compactly` to 0.2.0, which resolves both of the issues the current pins work around.

### `compactly-derive` pin (droundy/compactly#40)

`compactly` 0.1.7 required `compactly-derive` as `^0.1.7`, so pinning `compactly = "=0.1.7"` still resolved `compactly-derive` 0.1.8, which references symbols absent from the older lib. This repo worked around that with an explicit `compactly-derive = "=0.1.7"` dependency.

`compactly` 0.2.0 requires `compactly-derive = "=0.2.0"`, so the workaround dependency is dropped here, along with `"dep:compactly-derive"` from the `compactly` feature. `compactly` re-exports the derive, so nothing referenced it directly.

### `LowCardinality<String>` deprecation warning (droundy/compactly#41)

As of 0.1.8 the v2 derive warns on any `LowCardinality` field whose type mentions `String`: on a repeated value the `String` variant clones (reallocates) the cached value, whereas `Arc<str>` makes a cache hit a cheap refcount bump.

The dataset types here are shared by every encoding in the benchmark and deliberately mirror the upstream schema definitions, so switching these fields to `Arc<str>` would change what all the other encodings are measured on. Instead each affected field takes the `allow_string` opt-out that 0.2.0 adds:

```rust
#[cfg_attr(feature = "compactly", compactly(LowCardinality, allow_string))]
pub userid: String,
```

That covers 7 fields across `log` and `minecraft_savedata`. The two `Values<LowCardinality>` fields on `Vec<String>` are unaffected — the check only looks at the outermost strategy.

### Verification

- `cargo check --no-default-features --features compactly` — no warnings (and confirmed the warning does fire if `allow_string` is removed from a field).
- `cargo test --benches --no-default-features --features compactly` — serialize/deserialize round-trips pass on all four datasets.
- `cargo fmt --check` clean.

### Benchmark impact

0.2.0 is not neutral versus the currently pinned 0.1.7, so the published numbers will move. Measured locally on a quiesced machine (benchmarks pinned to an isolated CPU), `--no-default-features --features compactly`, so these are same-machine A/B numbers rather than anything comparable to the published run.

Time (criterion mean; confidence intervals were within ±0.2% on every row):

| benchmark | 0.1.7 | 0.2.0 | change |
| --- | ---: | ---: | ---: |
| log/serialize | 49.79 ms | 19.15 ms | -61.5% |
| log/deserialize | 31.16 ms | 28.55 ms | -8.4% |
| mesh/serialize | 775.65 ms | 589.18 ms | -24.0% |
| mesh/deserialize | 313.50 ms | 313.04 ms | -0.1% |
| minecraft_savedata/serialize | 18.34 ms | 10.43 ms | -43.1% |
| minecraft_savedata/deserialize | 13.07 ms | 12.61 ms | -3.5% |
| mk48/serialize | 109.20 ms | 80.74 ms | -26.1% |
| mk48/deserialize | 64.40 ms | 78.99 ms | **+22.6%** |

Size:

| dataset | 0.1.7 | 0.2.0 | change |
| --- | ---: | ---: | ---: |
| log | 239,520 | 237,188 | -0.97% |
| mesh | 4,846,788 | 5,208,739 | **+7.47%** |
| minecraft_savedata | 148,461 | 154,949 | **+4.37%** |
| mk48 | 800,772 | 805,900 | +0.64% |

Serialization is substantially faster on every dataset (-24% to -62%), against a size regression on mesh and minecraft_savedata. The one clear regression is mk48 deserialize at +22.6%, which I re-ran to confirm (63.95 ms vs 78.50 ms on the repeat).

These all come from upstream encoding changes between 0.1.7 and 0.2.0, not from the `allow_string` opt-out — that flag only silences the warning and does not affect the emitted encoding. I'll chase the mk48 deserialize and mesh size regressions on the compactly side separately; flagging here so the benchmark shift is expected rather than surprising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
