### PR TITLE
check the config json in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,11 @@ jobs:
         run: |
           git diff --exit-code && echo 'ok!' || (echo 'committed generated code is not up to date!'; exit 1)
 
+      - name: test tools and libs
+        shell: bash
+        run: |
+          cargo test --locked --workspace
+
       # build and test in dev mode with debug assertions enabled (and slow, uninteresting code
       # disabled; only the encoders, and not the compression). this should quickly sanity check
       # broken benchmarks, failing debug assertions, etc.

--- a/tools/schema/src/lib.rs
+++ b/tools/schema/src/lib.rs
@@ -50,6 +50,11 @@ impl Config {
     }
 }
 
+#[test]
+fn check_config() {
+    let _ = Config::read(Path::new("../config.json"));
+}
+
 #[derive(Default, Deserialize, Serialize)]
 pub struct Results {
     pub cpu_info: Option<String>,


### PR DESCRIPTION
this is like the second or third time typos in that file have been a problem, and they only show up at the very end of the benchmark. kinda silly